### PR TITLE
Extract baseUrl + api root into static method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 lib
 lib-esm
 _bundles
+yarn.lock

--- a/src/model.ts
+++ b/src/model.ts
@@ -132,13 +132,17 @@ export default class Model {
 
   static url(id?: string | number) : string {
     let endpoint = this.endpoint || `/${this.jsonapiType}`;
-    let base = `${this.baseUrl}${this.apiNamespace}${endpoint}`;
+    let base = `${this.fullBasePath()}${endpoint}`;
 
     if (id) {
       base = `${base}/${id}`;
     }
 
     return base;
+  }
+
+  static fullBasePath() : string {
+    return `${this.baseUrl}${this.apiNamespace}`;
   }
 
   static fromJsonapi(resource: japiResource, payload: japiDoc) : any {

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -26,14 +26,14 @@ export default class Scope {
 
   all() : Promise<CollectionProxy<Model>> {
     return this._fetch(this.model.url()).then((json : japiDoc) => {
-      let collection = new CollectionProxy(json);
+      let collection = new CollectionProxy<Model>(json);
       return collection;
     });
   }
 
   find(id : string | number) : Promise<RecordProxy<Model>> {
     return this._fetch(this.model.url(id)).then((json : japiDoc) => {
-      return new RecordProxy(json)
+      return new RecordProxy<Model>(json);
     });
   }
 
@@ -41,7 +41,7 @@ export default class Scope {
     let newScope = this.per(1);
     return newScope._fetch(newScope.model.url()).then((json : japiDoc) => {
       json.data = json.data[0];
-      return new RecordProxy(json);
+      return new RecordProxy<Model>(json);
     });
   }
 

--- a/test/unit/model-test.ts
+++ b/test/unit/model-test.ts
@@ -76,6 +76,33 @@ describe('Model', function() {
     });
   });
 
+  describe('.url', function() {
+    context('Default base URL generation method', function() {
+      it('should append the baseUrl, apiNamespace, and jsonapi type', function(){
+        class DefaultBaseUrl extends ApplicationRecord {
+          static baseUrl : string = 'http://base.com'
+          static apiNamespace : string = '/namespace/v1'
+          static jsonapiType : string = 'testtype'
+        }
+
+        expect(DefaultBaseUrl.url('testId')).to.eq('http://base.com/namespace/v1/testtype/testId')
+      })
+    })
+
+    context('Base URL path generation is overridden', function() {
+      it('should use the result of the override function', function(){
+        class OverriddenBaseUrl extends ApplicationRecord {
+          static jsonapiType : string = 'testtype'
+          static fullBasePath() : string {
+            return 'http://overridden.base'
+          }
+        }
+
+        expect(OverriddenBaseUrl.url('testId')).to.eq('http://overridden.base/testtype/testId')
+      })
+    })
+  })
+
   describe('#getJWT', function() {
     beforeEach(function() {
       ApplicationRecord.jwt = 'g3tm3';


### PR DESCRIPTION
This will allow consumers to inject additional functionality like being
able to live-switch the host or namespace at request time.