### PR TITLE
Add typings reference to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Javascript ORM",
   "main": "_bundles/jsorm.js",
   "module": "lib-esm/index.js",
+  "types": "lib-esm/index.d.ts",
   "author": "Lee Richmond",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Will allow typescript projects importing JSORM to find correct type
declarations.