### PR TITLE
Allow arbitrary fetch() options to be specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ lib
 lib-esm
 _bundles
 yarn.lock
+yarn-error.log

--- a/src/model.ts
+++ b/src/model.ts
@@ -12,7 +12,7 @@ import IncludeDirective from './util/include-directive';
 import DirtyChecker from './util/dirty-check';
 import ValidationErrors from './util/validation-errors';
 import relationshipIdentifiersFor from './util/relationship-identifiers';
-import Request from './request';
+import Request, { FetchOptions } from './request';
 import * as _cloneDeep from './util/clonedeep';
 let cloneDeep: any = (<any>_cloneDeep).default || _cloneDeep;
 if (cloneDeep.default) {
@@ -67,6 +67,12 @@ export default class Model {
 
     if (owner) {
       return owner.jwt;
+    }
+  }
+
+  static getFetchOptions() : FetchOptions {
+    return {
+      jwt: this.getJWT()
     }
   }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -12,7 +12,7 @@ import IncludeDirective from './util/include-directive';
 import DirtyChecker from './util/dirty-check';
 import ValidationErrors from './util/validation-errors';
 import relationshipIdentifiersFor from './util/relationship-identifiers';
-import Request, { FetchOptions } from './request';
+import Request from './request';
 import * as _cloneDeep from './util/clonedeep';
 let cloneDeep: any = (<any>_cloneDeep).default || _cloneDeep;
 if (cloneDeep.default) {
@@ -70,10 +70,19 @@ export default class Model {
     }
   }
 
-  static getFetchOptions() : FetchOptions {
-    return {
-      jwt: this.getJWT()
+  static fetchOptions() : RequestInit {
+    let options = {
+      headers: {
+        Accept: 'application/json',
+        ['Content-Type']: 'application/json'
+      } as any
     }
+
+    if (this.getJWT()) {
+      options.headers.Authorization = `Token token="${this.getJWT()}"`;
+    }
+
+    return options
   }
 
   static getJWTOwner() : typeof Model {

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,34 +1,28 @@
 import Config from './configuration';
 import colorize from './util/colorize';
-import cloneDeep from './util/clonedeep';
-
-// RequestInit is the type expected by `fetch()` API. 
-export interface FetchOptions extends RequestInit {
-  jwt? : string | undefined
-}
 
 export default class Request {
-  get(url : string, options: FetchOptions) : Promise<any> {
-    options['method'] = 'GET';
+  get(url : string, options: RequestInit) : Promise<any> {
+    options.method = 'GET';
     return this._fetchWithLogging(url, options);
   }
 
-  post(url: string, payload: Object, options: FetchOptions) : Promise<any> {
-    options['method'] = 'POST';
-    options['body']   = JSON.stringify(payload);
-
-    return this._fetchWithLogging(url, options);
-  }
-
-  put(url: string, payload: Object, options: FetchOptions) : Promise<any> {
-    options['method'] = 'PUT';
-    options['body']   = JSON.stringify(payload);
+  post(url: string, payload: Object, options: RequestInit) : Promise<any> {
+    options.method = 'POST';
+    options.body   = JSON.stringify(payload);
 
     return this._fetchWithLogging(url, options);
   }
 
-  delete(url: string, options: FetchOptions) : Promise<any> {
-    options['method'] = 'DELETE';
+  put(url: string, payload: Object, options: RequestInit) : Promise<any> {
+    options.method = 'PUT';
+    options.body   = JSON.stringify(payload);
+
+    return this._fetchWithLogging(url, options);
+  }
+
+  delete(url: string, options: RequestInit) : Promise<any> {
+    options.method = 'DELETE';
     return this._fetchWithLogging(url, options);
   }
 
@@ -42,8 +36,8 @@ export default class Request {
     Config.logger.debug(colorize('bold', JSON.stringify(responseJSON, null, 4)));
   }
 
-  private _fetchWithLogging(url: string, options: FetchOptions) : Promise<any> {
-    this._logRequest(options['method'], url);
+  private _fetchWithLogging(url: string, options: RequestInit) : Promise<any> {
+    this._logRequest(options.method, url);
     let promise = this._fetch(url, options);
     promise.then((response : any) => {
       this._logResponse(response['jsonPayload']);
@@ -51,14 +45,8 @@ export default class Request {
     return promise;
   }
 
-  private _fetch(url: string, opts: FetchOptions) : Promise<any> {
+  private _fetch(url: string, options: RequestInit) : Promise<any> {
     return new Promise((resolve, reject) => {
-      // Clone options since we are changing the object
-      let options : RequestInit = cloneDeep(opts as RequestInit)
-
-      let headers = this.buildHeaders(options);
-      options.headers = headers;
-
       let fetchPromise = fetch(url, options);
       fetchPromise.then((response) => {
         response.json().then((json) => {
@@ -69,23 +57,5 @@ export default class Request {
 
       fetchPromise.catch(reject);
     });
-  }
-
-  private buildHeaders(options: FetchOptions) : any {
-    let headers = {};
-
-    if (typeof options.headers == 'object') {
-      headers = options.headers 
-    }
-
-    headers['Accept'] = 'application/json';
-    headers['Content-Type'] = 'application/json';
-
-    if (options.jwt) {
-      headers['Authorization'] = `Token token="${options.jwt}"`;
-      delete options.jwt
-    }
-
-    return headers;
   }
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,27 +1,33 @@
 import Config from './configuration';
 import colorize from './util/colorize';
+import cloneDeep from './util/clonedeep';
+
+// RequestInit is the type expected by `fetch()` API. 
+export interface FetchOptions extends RequestInit {
+  jwt? : string | undefined
+}
 
 export default class Request {
-  get(url : string, options: Object) : Promise<any> {
+  get(url : string, options: FetchOptions) : Promise<any> {
     options['method'] = 'GET';
     return this._fetchWithLogging(url, options);
   }
 
-  post(url: string, payload: Object, options: Object) : Promise<any> {
+  post(url: string, payload: Object, options: FetchOptions) : Promise<any> {
     options['method'] = 'POST';
     options['body']   = JSON.stringify(payload);
 
     return this._fetchWithLogging(url, options);
   }
 
-  put(url: string, payload: Object, options: Object) : Promise<any> {
+  put(url: string, payload: Object, options: FetchOptions) : Promise<any> {
     options['method'] = 'PUT';
     options['body']   = JSON.stringify(payload);
 
     return this._fetchWithLogging(url, options);
   }
 
-  delete(url: string, options: Object) : Promise<any> {
+  delete(url: string, options: FetchOptions) : Promise<any> {
     options['method'] = 'DELETE';
     return this._fetchWithLogging(url, options);
   }
@@ -36,7 +42,7 @@ export default class Request {
     Config.logger.debug(colorize('bold', JSON.stringify(responseJSON, null, 4)));
   }
 
-  private _fetchWithLogging(url: string, options: Object) : Promise<any> {
+  private _fetchWithLogging(url: string, options: FetchOptions) : Promise<any> {
     this._logRequest(options['method'], url);
     let promise = this._fetch(url, options);
     promise.then((response : any) => {
@@ -45,10 +51,13 @@ export default class Request {
     return promise;
   }
 
-  private _fetch(url: string, options: Object) : Promise<any> {
+  private _fetch(url: string, opts: FetchOptions) : Promise<any> {
     return new Promise((resolve, reject) => {
+      // Clone options since we are changing the object
+      let options : RequestInit = cloneDeep(opts as RequestInit)
+
       let headers = this.buildHeaders(options);
-      options['headers'] = headers;
+      options.headers = headers;
 
       let fetchPromise = fetch(url, options);
       fetchPromise.then((response) => {
@@ -57,17 +66,24 @@ export default class Request {
           resolve(response);
         }).catch((e) => { throw(e); });
       });
+
       fetchPromise.catch(reject);
     });
   }
 
-  private buildHeaders(options: Object) : any {
+  private buildHeaders(options: FetchOptions) : any {
     let headers = {};
+
+    if (typeof options.headers == 'object') {
+      headers = options.headers 
+    }
+
     headers['Accept'] = 'application/json';
     headers['Content-Type'] = 'application/json';
 
-    if (options['jwt']) {
-      headers['Authorization'] = `Token token="${options['jwt']}"`;
+    if (options.jwt) {
+      headers['Authorization'] = `Token token="${options.jwt}"`;
+      delete options.jwt
     }
 
     return headers;

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -219,9 +219,9 @@ export default class Scope {
       url = `${url}?${qp}`;
     }
     let request = new Request();
-    let jwt = this.model.getJWT();
+    let fetchOpts = this.model.getFetchOptions()
 
-    return request.get(url, { jwt }).then((response) => {
+    return request.get(url, fetchOpts).then((response) => {
       let jwtHeader = response.headers.get('X-JWT');
       if (jwtHeader) {
         this.model.setJWT(jwtHeader);

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -219,7 +219,7 @@ export default class Scope {
       url = `${url}?${qp}`;
     }
     let request = new Request();
-    let fetchOpts = this.model.getFetchOptions()
+    let fetchOpts = this.model.fetchOptions()
 
     return request.get(url, fetchOpts).then((response) => {
       let jwtHeader = response.headers.get('X-JWT');

--- a/test/unit/model-test.ts
+++ b/test/unit/model-test.ts
@@ -134,6 +134,20 @@ describe('Model', function() {
     });
   });
 
+  describe('#getFetchOptions', function() {
+    beforeEach(function() {
+      ApplicationRecord.jwt = 'g3tm3';
+    });
+
+    afterEach(function() {
+      ApplicationRecord.jwt = null;
+    });
+
+    it('includes the jwt', function() {
+      expect(Author.getFetchOptions().jwt).to.eq('g3tm3');
+    });
+  })
+
   describe('#isType', function() {
     it('checks the jsonapiType of class', function() {
       instance = new Author()

--- a/test/unit/model-test.ts
+++ b/test/unit/model-test.ts
@@ -134,18 +134,26 @@ describe('Model', function() {
     });
   });
 
-  describe('#getFetchOptions', function() {
-    beforeEach(function() {
-      ApplicationRecord.jwt = 'g3tm3';
-    });
+  describe('#fetchOptions', function() {
+    context('jwt is set', function() {
+      beforeEach(function() {
+        ApplicationRecord.jwt = 'g3tm3';
+      });
 
-    afterEach(function() {
-      ApplicationRecord.jwt = null;
-    });
+      afterEach(function() {
+        ApplicationRecord.jwt = null;
+      });
 
-    it('includes the jwt', function() {
-      expect(Author.getFetchOptions().jwt).to.eq('g3tm3');
-    });
+      it('sets the auth header', function() {
+        expect(Author.fetchOptions().headers.Authorization).to.eq('Token token="g3tm3"');
+      });
+    })
+
+    it('includes the content headers', function() {
+      let headers = Author.fetchOptions().headers
+      expect(headers.Accept).to.eq('application/json')
+      expect(headers['Content-Type']).to.eq('application/json')
+    })
   })
 
   describe('#isType', function() {


### PR DESCRIPTION
Previously we could only set the JWT token on the underlying fetch()
call. Now any model can enhance the fetch options by overriding
`getFetchOptions()`.