### PR TITLE
Fix bug with deeply nested associations

### DIFF
--- a/src/util/deserialize.ts
+++ b/src/util/deserialize.ts
@@ -147,7 +147,8 @@ class Deserializer {
         let hydratedDatum = this.findResource(relationData);
         let existing = instance[relationName];
         let associated = existing || this.instanceFor(hydratedDatum.type);
-        this.deserializeInstance(associated, hydratedDatum, nestedIncludeDirective);
+
+        associated = this.deserializeInstance(associated, hydratedDatum, nestedIncludeDirective);
 
         if (!existing) {
           instance[relationName] = associated;

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -40,6 +40,7 @@ class Book extends ApplicationRecord {
   title: string = attr();
 
   genre = belongsTo('genres');
+  author = hasOne('authors')
 }
 
 class Genre extends ApplicationRecord {

--- a/test/unit/model-test.ts
+++ b/test/unit/model-test.ts
@@ -198,6 +198,9 @@ describe('Model', function() {
             data: [{
               id: '1',
               type: 'books'
+            }, {
+              id: '2',
+              type: 'books'
             }]
           },
           bio: {
@@ -217,6 +220,29 @@ describe('Model', function() {
           id: '1',
           attributes: {
             title: "Where's My Butt?"
+          },
+          relationships: {
+            author: {
+              data: { 
+                id: '2', 
+                type: 'authors' 
+              },
+            }
+          }
+        },
+        {
+          type: 'books',
+          id: '2',
+          attributes: {
+            title: "Catcher in the Rye"
+          },
+          relationships: {
+            author: {
+              data: { 
+                id: '2', 
+                type: 'authors' 
+              },
+            }
           }
         },
         {
@@ -300,7 +326,7 @@ describe('Model', function() {
 
     it('assigns hasMany relationships correctly', function() {
       let instance = Model.fromJsonapi(doc.data, doc);
-      expect(instance.books.length).to.eq(1);
+      expect(instance.books.length).to.eq(2);
       let book = instance.books[0];
       expect(book).to.be.instanceof(Book);
       expect(book.title).to.eq("Where's My Butt?");
@@ -328,6 +354,15 @@ describe('Model', function() {
       expect(authors[1]).to.be.instanceof(Author);
       expect(authors[0].firstName).to.eq('Donald Budge');
       expect(authors[1].firstName).to.eq('Maurice Sendak');
+    });
+
+    it('assigns duplicated nested relationships correctly', function() {
+      let instance = Model.fromJsonapi(doc.data, doc);
+      let book1 = instance.books[0];
+      let book2 = instance.books[1];
+
+      expect(book1.author.firstName).to.eq("Maurice Sendak");
+      expect(book2.author.firstName).to.eq("Maurice Sendak");
     });
 
     it('skips relationships without data', function() {


### PR DESCRIPTION
This fixes an issue when looking up/assigning a deep assocation that had
already been assigned to another object would assign an empty copy of
the object instead of the target.  It was doing this because the return
value of the lookup wasn't being used, and instead the function was
inadvertently relying on the modification to the passed in parameter.