### PR TITLE
Make error validation immutable

### DIFF
--- a/test/integration/validations-test.ts
+++ b/test/integration/validations-test.ts
@@ -110,6 +110,32 @@ describe('validations', function() {
     });
   });
 
+  it('instantiates a new error object instance after save', function(done) {
+    let originalErrors = instance.errors = {foo: 'bar'};
+    let result = instance.save({ with: { books: 'genre' }});
+    let postSavePreValidateErrors = instance.errors;
+
+    expect(postSavePreValidateErrors).not.to.equal(originalErrors);
+
+    result.then(() => {
+      done()
+    }).catch(done)
+  })
+
+  it('instantiates a new error object instance after validate', function(done) {
+    let result = instance.save({ with: { books: 'genre' }});
+
+    let postSavePreValidateErrors = instance.errors;
+
+    result.then((val) => {
+      let postValidateErrors = instance.errors;
+
+      expect(postValidateErrors).not.to.equal(postSavePreValidateErrors);
+
+      done()
+    }).catch(done)
+  })
+
   it('applies errors to nested hasMany relationships', function(done) {
     instance.save({ with: { books: 'genre' }}).then((success) => {
       expect(instance.isPersisted()).to.eq(false);


### PR DESCRIPTION
Previously the model errors object was being cleared out on save and
then the validator was appending all errors to that empty object after
the result set came back.  This is problematic for frameworks like
vue.js which rely on object observers, as an observer change event is
not fired when the new errors are added unless the developer
specifically requests a deep object watch, with is both computationally
expensive and something that has to be done every time.  This replaces
the behavior by creating a new errors object each time the validator is
run and replacing the one currently on the model with it.