### PR TITLE
Add isMarkedForDisassociation()

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -38,6 +38,7 @@ export default class Model {
   __meta__: Object | void = null;
   _persisted: boolean = false;
   _markedForDestruction: boolean = false;
+  _markedForDisassociation: boolean = false;
   klass: typeof Model;
 
   static attributeList = [];
@@ -230,6 +231,15 @@ export default class Model {
       return val;
     } else {
       return this._markedForDestruction;
+    }
+  }
+
+  isMarkedForDisassociation(val? : boolean) : boolean {
+    if (val != undefined) {
+      this._markedForDisassociation = val;
+      return val;
+    } else {
+      return this._markedForDisassociation;
     }
   }
 

--- a/src/util/deserialize.ts
+++ b/src/util/deserialize.ts
@@ -112,7 +112,7 @@ class Deserializer {
       if (relatedObjects) {
         if (Array.isArray(relatedObjects)) {
           relatedObjects.forEach((relatedObject, index) => {
-            if (relatedObject.isMarkedForDestruction()) {
+            if (relatedObject.isMarkedForDestruction() || relatedObject.isMarkedForDisassociation()) {
               model[key].splice(index, 1);
             } else {
               this._removeDeletions(relatedObject, includeDirective[key] || {});
@@ -120,7 +120,7 @@ class Deserializer {
           });
         } else {
           let relatedObject = relatedObjects;
-          if (relatedObject.isMarkedForDestruction()) {
+          if (relatedObject.isMarkedForDestruction() || relatedObject.isMarkedForDisassociation()) {
             model[key] = null;
           } else {
             this._removeDeletions(relatedObject, includeDirective[key] || {});

--- a/src/util/dirty-check.ts
+++ b/src/util/dirty-check.ts
@@ -27,7 +27,7 @@ class DirtyChecker {
 
   // Either:
   // * attributes changed
-  // * marked for destruction
+  // * marked for destruction / disassociation
   // * not persisted (and thus must be send to server)
   // * not itself dirty, but has nested relations that are dirty
   check(relationships: Object | Array<any> | string = {}) : boolean {
@@ -37,6 +37,7 @@ class DirtyChecker {
     return this._hasDirtyAttributes() ||
       this._hasDirtyRelationships(includeHash) ||
       this.model.isMarkedForDestruction() ||
+      this.model.isMarkedForDisassociation() ||
       this._isUnpersisted()
   }
 

--- a/src/util/write-payload.ts
+++ b/src/util/write-payload.ts
@@ -35,7 +35,7 @@ export default class WritePayload {
       if (relatedObjects) {
         if (Array.isArray(relatedObjects)) {
           relatedObjects.forEach((relatedObject, index) => {
-            if (relatedObject.isMarkedForDestruction()) {
+            if (relatedObject.isMarkedForDestruction() || relatedObject.isMarkedForDisassociation()) {
               model[key].splice(index, 1);
             } else {
               this.removeDeletions(relatedObject, nested);
@@ -43,7 +43,7 @@ export default class WritePayload {
           });
         } else {
           let relatedObject = relatedObjects;
-          if (relatedObject.isMarkedForDestruction()) {
+          if (relatedObject.isMarkedForDestruction() || relatedObject.isMarkedForDisassociation()) {
             model[key] = null;
           } else {
             this.removeDeletions(relatedObject, nested);
@@ -161,8 +161,10 @@ export default class WritePayload {
     if (model.isPersisted()) {
       if (model.isMarkedForDestruction()) {
         method = 'destroy';
+      } else if (model.isMarkedForDisassociation()) {
+        method = 'disassociate';
       } else {
-        method = 'update'
+        method = 'update';
       }
     } else {
       method = 'create';

--- a/test/integration/nested-persistence-test.ts
+++ b/test/integration/nested-persistence-test.ts
@@ -302,7 +302,33 @@ describe('nested persistence', function() {
   });
 
   describe('basic nested disassociate', function() {
-    xit('sends the correct payload', function() {
+    beforeEach(function() {
+      seedPersistedData();
+    });
+
+    it('sends the correct payload', function(done) {
+      instance.books[0].isMarkedForDisassociation(true);
+      instance.books[0].genre.isMarkedForDisassociation(true);
+      instance.save({ with: { books: 'genre' } }).then((response) => {
+        expect(putPayloads[0]).to.deep.equal(expectedUpdatePayload('disassociate'));
+        done();
+      });
+    });
+
+    it('removes the associated has_many data', function(done) {
+      instance.books[0].isMarkedForDisassociation(true);
+      instance.save({ with: 'books' }).then((response) => {
+        expect(instance.books.length).to.eq(0);
+        done();
+      });
+    });
+
+    it('removes the associated belongs_to data', function(done) {
+      instance.books[0].genre.isMarkedForDisassociation(true);
+      instance.save({ with: { books: 'genre' } }).then((response) => {
+        expect(instance.books[0].genre).to.eq(null);
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
This replicates all the logic from isMarkedForDestruction, but sends the
'dissassociate' method instead of the 'destroy' method. The biggest
thing that might look off here is some duplicative specs, but I'm OK
with this for now.