### PR TITLE
Allow unpersisted attributes

### DIFF
--- a/src/attribute.ts
+++ b/src/attribute.ts
@@ -7,12 +7,19 @@ import Config from './configuration';
 export default class Attribute {
   name: string;
 
+  persist: boolean = true;
   isAttr: boolean = true;
   isRelationship: boolean = false;
 
+  constructor(opts?: attributeOptions) {
+    if (opts && opts.hasOwnProperty('persist')) {
+      this.persist = opts.persist;
+    }
+  }
+
   static applyAll(klass: typeof Model) : void {
     this._eachAttribute(klass, (attr) => {
-      klass.attributeList.push(attr.name);
+      klass.attributeList[attr.name] = attr;
       let descriptor = attr.descriptor();
       Object.defineProperty(klass.prototype, attr.name, descriptor);
       let instance = new klass();

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,8 +12,8 @@ import Attribute from './attribute';
 import attrDecorator from './util/attr-decorator';
 import { hasMany, hasOne, belongsTo } from './associations';
 
-const attr = function() : any {
-  return new Attribute();
+const attr = function(opts?: attributeOptions) : any {
+  return new Attribute(opts);
 }
 
 export { Config, Model, attr, attrDecorator, hasMany, hasOne, belongsTo, patchExtends };

--- a/src/model.ts
+++ b/src/model.ts
@@ -41,7 +41,7 @@ export default class Model {
   _markedForDisassociation: boolean = false;
   klass: typeof Model;
 
-  static attributeList = [];
+  static attributeList = {};
   static relationList = [];
   private static _scope: Scope;
 
@@ -208,7 +208,7 @@ export default class Model {
   assignAttributes(attrs: Object) {
     for(var key in attrs) {
       let attributeName = camelize(key);
-      if (key == 'id' || this.klass.attributeList.indexOf(attributeName) >= 0) {
+      if (key == 'id' || this.klass.attributeList[attributeName]) {
         this[attributeName] = attrs[key];
       }
     }

--- a/src/util/deserialize.ts
+++ b/src/util/deserialize.ts
@@ -160,7 +160,7 @@ class Deserializer {
   _iterateValidRelationships(instance, relationships, callback) {
     for (let key in relationships) {
       let relationName = camelize(key);
-      if (instance.klass.attributeList.indexOf(relationName) >= 0) {
+      if (instance.klass.attributeList[relationName]) {
         let relationData = relationships[key].data;
         if(!relationData) continue; // only links, empty, etc
         callback(relationName, relationData);

--- a/src/util/write-payload.ts
+++ b/src/util/write-payload.ts
@@ -194,8 +194,10 @@ export default class WritePayload {
   private _eachAttribute(callback: Function) : void {
     let modelAttrs = this.model.attributes;
     Object.keys(modelAttrs).forEach((key) => {
-      let value = modelAttrs[key];
-      callback(key, value);
+      if (this.model.klass.attributeList[key].persist) {
+        let value = modelAttrs[key];
+        callback(key, value);
+      }
     });
   }
 }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -14,6 +14,10 @@ class Person extends ApplicationRecord {
   lastName: string = attr();
 }
 
+class PersonWithExtraAttr extends Person {
+  extraThing: string = attr({ persist: false });
+}
+
 // Ensure setup() can be run multiple times with no problems
 // putting this here, otherwise relations wont be available.
 Config.setup();
@@ -86,6 +90,7 @@ export {
   NonJWTOwner,
   Author,
   Person,
+  PersonWithExtraAttr,
   Book,
   Genre,
   Bio,

--- a/test/integration/persistence-test.ts
+++ b/test/integration/persistence-test.ts
@@ -1,5 +1,5 @@
 import { expect, fetchMock } from '../test-helper';
-import { Person } from '../fixtures';
+import { Person, PersonWithExtraAttr } from '../fixtures';
 
 let fetchMock = require('fetch-mock');
 
@@ -51,6 +51,17 @@ describe('Model persistence', function() {
   });
 
   describe('#save()', function() {
+    describe('when a unpersisted attr', function() {
+      it('does not send the attr to server', function(done) {
+        instance = new PersonWithExtraAttr({ extraThing: 'foo' });
+        expect(instance.extraThing).to.eq('foo');
+        instance.save().then(() => {
+          expect(payloads[0]['data']['attributes']).to.eq(undefined);
+          done()
+        });
+      });
+    });
+
     describe('when the model is already persisted', function() {
       beforeEach(function() {
         instance.id = '1';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -29,3 +29,7 @@ interface IResultProxy<T> {
   meta: Object
   raw: japiDoc
 }
+
+interface attributeOptions {
+  persist: boolean;
+}


### PR DESCRIPTION
You may have an attribute from a selectExtra, like fooCount, that should
not be sent to the server. You can now `attr({ persist: false })` for
these cases.