### PR TITLE
When saving, only send dirty attributes

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -256,6 +256,11 @@ export default class Model {
     return dc.check(relationships);
   }
 
+  changes() : Object {
+    let dc = new DirtyChecker(this);
+    return dc.dirtyAttributes();
+  }
+
   hasDirtyRelation(relationName: string, relatedModel: Model) : boolean {
     let dc = new DirtyChecker(this);
     return dc.checkRelation(relationName, relatedModel);

--- a/src/util/dirty-check.ts
+++ b/src/util/dirty-check.ts
@@ -41,6 +41,23 @@ class DirtyChecker {
       this._isUnpersisted()
   }
 
+  dirtyAttributes() : Object {
+    let dirty = {};
+
+    for (let key of Object.keys(this.model.attributes)) {
+      let prior = this.model._originalAttributes[key];
+      let current = this.model.attributes[key];
+
+      if (!this.model.isPersisted()) {
+        dirty[key] = [null, current];
+      } else if (prior != current) {
+        dirty[key] = [prior, current]
+      }
+    }
+
+    return dirty;
+  }
+
   // TODO: allow attributes == {} configurable
   private _isUnpersisted() {
     return !this.model.isPersisted() && JSON.stringify(this.model.attributes) !== JSON.stringify({});

--- a/src/util/write-payload.ts
+++ b/src/util/write-payload.ts
@@ -21,7 +21,10 @@ export default class WritePayload {
 
     this._eachAttribute((key, value) => {
       let snakeKey    = snakeCase(key);
-      attrs[snakeKey] = value;
+
+      if (!this.model.isPersisted() || this.model.changes()[key]) {
+        attrs[snakeKey] = value;
+      }
     });
 
     return attrs;

--- a/test/integration/nested-persistence-test.ts
+++ b/test/integration/nested-persistence-test.ts
@@ -77,7 +77,6 @@ let expectedUpdatePayload = function(method) {
     data: {
       id: '1',
       type: 'authors',
-      attributes: { first_name: 'Stephen' },
       relationships: {
         books: {
           data: [
@@ -206,7 +205,6 @@ describe('nested persistence', function() {
     // todo test on the way back - id set, attrs updated, isPersisted
     // todo remove #destroy? and just save when markwithpersisted? combo? for ombined payload
     // todo test unique includes/circular relationshio
-    // todo only send dirty
     it('sends the correct payload', function(done) {
       instance.save({ with: { books: 'genre' } }).then((response) => {
         expect(payloads[0]).to.deep.equal(expectedCreatePayload);

--- a/test/integration/persistence-test.ts
+++ b/test/integration/persistence-test.ts
@@ -51,7 +51,7 @@ describe('Model persistence', function() {
   });
 
   describe('#save()', function() {
-    describe('when a unpersisted attr', function() {
+    describe('when an unpersisted attr', function() {
       it('does not send the attr to server', function(done) {
         instance = new PersonWithExtraAttr({ extraThing: 'foo' });
         expect(instance.extraThing).to.eq('foo');
@@ -92,6 +92,26 @@ describe('Model persistence', function() {
           expect(instance.isPersisted()).to.eq(true);
         });
       });
+
+      describe('when no dirty attributes', function() {
+        beforeEach(function() {
+          instance.firstName = 'Joe';
+          instance.isPersisted(true);
+        });
+
+        it('does not send attributes to the server', function(done) {
+          instance.save().then(() => {
+            console.log(putPayloads[0])
+            expect(putPayloads[0]).to.deep.equal({
+              data: {
+                id: '1',
+                type: 'people'
+              }
+            });
+            done();
+          });
+        });
+      })
     });
 
     describe('when the model is not already persisted', function() {

--- a/test/unit/model-test.ts
+++ b/test/unit/model-test.ts
@@ -617,6 +617,31 @@ describe('Model', function() {
     });
   });
 
+  describe('changes', function() {
+    describe('when unpersisted', function() {
+      it('counts everything but nulls', function() {
+        instance = new Author({ firstName: 'foo' });
+        expect(instance.changes()).to.deep.equal({
+          firstName: [null, 'foo']
+        });
+      });
+    });
+
+    describe('when persisted', function() {
+      it('only counts dirty attrs', function() {
+        instance = new Author({ firstName: 'foo' });
+        instance.isPersisted(true);
+        expect(instance.changes()).to.deep.equal({});
+        instance.firstName = 'bar'
+        expect(instance.changes()).to.deep.equal({
+          firstName: ['foo', 'bar']
+        });
+        instance.isPersisted(true);
+        expect(instance.changes()).to.deep.equal({});
+      });
+    });
+  });
+
   describe('isDirty', function() {
     describe('when an attribute changes', function() {
       it('is marked as dirty', function() {


### PR DESCRIPTION
Currently, saving will always send all attributes to the server. This is
a bug; we should only send dirty attributes. This is to better ensure
users don't accidentally overwrite each others' data.