### PR TITLE
Fix attribute inheritance bug

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -3,6 +3,11 @@
 import Model from './model';
 import Attribute from './attribute';
 import Logger from './logger';
+import * as _cloneDeep from './util/clonedeep';
+let cloneDeep: any = (<any>_cloneDeep).default || _cloneDeep;
+if (cloneDeep.default) {
+  cloneDeep = cloneDeep.default;
+}
 
 let ctx = this;
 
@@ -24,6 +29,12 @@ export default class Config {
 
     for (let model of this.models) {
       Attribute.applyAll(model);
+    }
+
+    for (let model of this.models) {
+      let parentAttrList = cloneDeep(model.parentClass.attributeList);
+      let attrList = cloneDeep(model.attributeList);
+      model.attributeList = Object.assign(parentAttrList, attrList);
     }
   }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -42,7 +42,6 @@ export default class Model {
   klass: typeof Model;
 
   static attributeList = {};
-  static relationList = [];
   private static _scope: Scope;
 
   static extend(obj : any) : any {
@@ -53,6 +52,7 @@ export default class Model {
     Config.models.push(subclass)
     subclass.parentClass = this;
     subclass.prototype.klass = subclass;
+    subclass.attributeList = cloneDeep(subclass.attributeList)
   }
 
   static scope(): Scope {

--- a/test/integration/finders-test.ts
+++ b/test/integration/finders-test.ts
@@ -19,7 +19,7 @@ describe('Model finders', function() {
           id: '1',
           type: 'people',
           attributes: {
-            name: 'John'
+            firstName: 'John'
           }
         }
       });
@@ -35,7 +35,7 @@ describe('Model finders', function() {
 
     it('assigns attributes correctly', function(done) {
       resultData(Person.find(1)).then((data) => {
-        expect(data).to.have.property('name', 'John');
+        expect(data).to.have.property('firstName', 'John');
         done();
       });
     });

--- a/test/unit/attributes-test.ts
+++ b/test/unit/attributes-test.ts
@@ -36,5 +36,19 @@ describe('Model attributes', function() {
       let person = new Person({ foo: 'bar' });
       expect(person['foo']).to.eq(undefined);
     });
+
+    describe('but that attribute exists in an unrelated model', function() {
+      it('still silently drops', function() {
+        let person = new Person({ title: 'bar' });
+        expect(person['title']).to.eq(undefined);
+      });
+    });
+
+    describe('but that attribute exists in a subclass', function() {
+      it('still silently drops', function() {
+        let person = new Person({ extraThing: 'bar' });
+        expect(person['extraThing']).to.eq(undefined);
+      });
+    });
   })
 });


### PR DESCRIPTION
Though user-facing behavior was (mostly) unaffected, there was an
under-the-hood issue with unrelated models getting each others'
attributes.

The `Model.attributeList` was being shared across all models - you'd see
typescript errors but if you ignored them you would have shared
attribute lists across models. In other words:

```ts
class Person extends ApplicationRecord {
  firstName = attr()
}

class Truck extends ApplicationRecord {
  wheels = attr()
}

let p = new Person();
p.wheels // typescript error, but p['wheels'] works
// and vice versa for Truck['firstName']

// In a practical sense, here's the real-world bug:
let truck = new Truck({ firstName: 'foo' })
expect(truck['firstName']).to.eq(undefined) // but is actually 'foo'
```

To fix this, ensure we clone the `attributeList` within the `inherited`
hook, so each class has its own unique attributeList. However, this
means subclasses will no longer inherit their parents' attributes. So,
after we define all the attribute lists, merge parent and child lists.