### PR TITLE
Define attributes on instance, not prototype

### DIFF
--- a/src/attribute.ts
+++ b/src/attribute.ts
@@ -21,7 +21,6 @@ export default class Attribute {
     this._eachAttribute(klass, (attr) => {
       klass.attributeList[attr.name] = attr;
       let descriptor = attr.descriptor();
-      Object.defineProperty(klass.prototype, attr.name, descriptor);
       let instance = new klass();
 
       let decorators = instance['__attrDecorators'] || [];

--- a/src/model.ts
+++ b/src/model.ts
@@ -166,6 +166,7 @@ export default class Model {
   }
 
   constructor(attributes?: Object) {
+    this._initializeAttributes();
     this.attributes = attributes;
     this._originalAttributes = cloneDeep(this.attributes);
     this._originalRelationships = this.relationshipResourceIdentifiers(Object.keys(this.relationships));
@@ -266,6 +267,10 @@ export default class Model {
     return dc.checkRelation(relationName, relatedModel);
   }
 
+  dup() : Model {
+    return cloneDeep(this);
+  }
+
   destroy() : Promise<any> {
     let url     = this.klass.url(this.id);
     let verb    = 'delete';
@@ -295,6 +300,15 @@ export default class Model {
       //this.isPersisted(true);
       payload.postProcess();
     });
+  }
+
+  // Define getter/setters and set defaults
+  private _initializeAttributes() {
+    for (let key in this.klass.attributeList) {
+      let attr = this.klass.attributeList[key];
+      Object.defineProperty(this, attr.name, attr.descriptor());
+      this[key] = this[key]; // set defaults
+    }
   }
 
   private _writeRequest(requestPromise : Promise<any>, callback: Function) : Promise<any> {

--- a/test/unit/attributes-test.ts
+++ b/test/unit/attributes-test.ts
@@ -1,5 +1,5 @@
 import { sinon, expect } from '../test-helper';
-import { Person } from '../fixtures';
+import { Person, Author } from '../fixtures';
 
 describe('Model attributes', function() {
   it('supports direct assignment', function() {
@@ -27,6 +27,18 @@ describe('Model attributes', function() {
     expect(person.attributes).to.eql({ firstName: 'John' });
     person.attributes['firstName'] = 'Jane';
     expect(person.firstName).to.eq('Jane');
+  });
+
+  it('sets attributes properties on the instance', function() {
+    let person = new Person();
+    expect(person.hasOwnProperty('firstName')).to.eq(true);
+    expect(Object.getOwnPropertyDescriptor(person, 'firstName'))
+      .to.not.eq(undefined);
+  });
+
+  it('defaults hasMany before the getter is called', function() {
+    let author = new Author();
+    expect(author.relationships['books']).to.deep.eq([])
   });
 
   // Without this behavior, the API could add a backwards-compatible field,


### PR DESCRIPTION
* Ensures `Object.getOwnPropertyDescriptor(modelInstance, 'attr')` will
accurately return the descriptor. This is needed by VueJS to call the
original getter/setters when setting up the reactive getter/setter
overrides.
* Immediately assigns all attributes - this is because the getter will
set a default when first called. Required by VueJS to track association
arrays.
* Adds `dup()` convensience method.