### PR TITLE
Optionally add JWT to localStorage

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -15,15 +15,23 @@ export default class Config {
   static models: Array<typeof Model> = [];
   static typeMapping: Object = {};
   static logger: Logger = new Logger();
+  static jwtLocalStorage: string | false = 'jwt';
+  static localStorage;
 
   static setup(options? : Object) : void {
     if (!options) options = {};
+
+    this.jwtLocalStorage = options['jwtLocalStorage'];
 
     for (let model of this.models) {
       this.typeMapping[model.jsonapiType] = model;
 
       if (options['jwtOwners'] && options['jwtOwners'].indexOf(model) !== -1) {
         model.isJWTOwner = true;
+
+        if (this.jwtLocalStorage) {
+          model.jwt = this.localStorage.getItem(this.jwtLocalStorage);
+        }
       }
     }
 
@@ -51,4 +59,11 @@ export default class Config {
       throw(`Could not find class for jsonapi type "${type}"`)
     }
   }
+}
+
+// In node, no localStorage available
+// We do this so we can mock it
+try {
+  Config.localStorage = localStorage
+} catch(e) {
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -11,6 +11,7 @@ import WritePayload from './util/write-payload';
 import IncludeDirective from './util/include-directive';
 import DirtyChecker from './util/dirty-check';
 import ValidationErrors from './util/validation-errors';
+import refreshJWT from './util/refresh-jwt';
 import relationshipIdentifiersFor from './util/relationship-identifiers';
 import Request from './request';
 import * as _cloneDeep from './util/clonedeep';
@@ -321,6 +322,8 @@ export default class Model {
   }
 
   private _handleResponse(response: any, resolve: Function, reject: Function, callback: Function) : void {
+    refreshJWT(this.klass, response);
+
     if (response.status == 422) {
       ValidationErrors.apply(this, response['jsonPayload']);
       resolve(false);

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -5,6 +5,7 @@ import IncludeDirective from './util/include-directive';
 import { CollectionProxy, RecordProxy } from './proxies';
 import Request from './request';
 import colorize from './util/colorize';
+import refreshJWT from './util/refresh-jwt';
 import * as _cloneDeep from './util/clonedeep';
 let cloneDeep: any = (<any>_cloneDeep).default || _cloneDeep;
 cloneDeep = cloneDeep.default || cloneDeep;
@@ -222,10 +223,7 @@ export default class Scope {
     let fetchOpts = this.model.fetchOptions()
 
     return request.get(url, fetchOpts).then((response) => {
-      let jwtHeader = response.headers.get('X-JWT');
-      if (jwtHeader) {
-        this.model.setJWT(jwtHeader);
-      }
+      refreshJWT(this.model, response);
       return response['jsonPayload'];
     });
   }

--- a/src/util/refresh-jwt.ts
+++ b/src/util/refresh-jwt.ts
@@ -1,0 +1,18 @@
+import Model from '../model';
+import Config from '../configuration';
+
+export default function refreshJWT(klass: typeof Model, serverResponse: Response) : void {
+  let jwt = serverResponse.headers.get('X-JWT');
+  let localStorage = Config.localStorage;
+
+  if (localStorage) {
+    let localStorageKey = Config.jwtLocalStorage;
+    if (localStorageKey) {
+      localStorage['setItem'](localStorageKey, jwt);
+    }
+  }
+
+  if (jwt) {
+    klass.setJWT(jwt);
+  }
+}

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -78,14 +78,17 @@ const TestJWTSubclass = ApplicationRecord.extend({
 const NonJWTOwner = Model.extend({
 });
 
-Config.setup({
-  jwtOwners: [
+const configSetup = function(opts = {}) {
+  opts['jwtOwners'] = [
     ApplicationRecord,
     TestJWTSubclass
   ]
-});
+  Config.setup(opts);
+}
+configSetup();
 
 export {
+  configSetup,
   ApplicationRecord,
   TestJWTSubclass,
   NonJWTOwner,

--- a/test/integration/authorization-test.ts
+++ b/test/integration/authorization-test.ts
@@ -1,5 +1,6 @@
-import { expect, fetchMock } from '../test-helper';
-import { ApplicationRecord, Author } from '../fixtures';
+import { sinon, expect, fetchMock } from '../test-helper';
+import { Config } from '../../src/index';
+import { configSetup, ApplicationRecord, Author } from '../fixtures';
 
 after(function () {
   fetchMock.restore();
@@ -87,6 +88,111 @@ describe('authorization headers', function() {
         expect(Author.getJWT()).to.eq('somet0k3n');
         expect(ApplicationRecord.jwt).to.eq('somet0k3n');
         Author.all();
+      });
+    });
+
+    describe('local storage', function() {
+      beforeEach(function() {
+        Config.localStorage = { setItem: sinon.spy() }
+        Config.jwtLocalStorage = 'jwt';
+      });
+
+      afterEach(function() {
+        Config.localStorage = undefined;
+        Config.jwtLocalStorage = undefined;
+      });
+
+      describe('when configured to store jwt', function() {
+        beforeEach(function() {
+          Config.jwtLocalStorage = 'jwt';
+        });
+
+        it('updates localStorage on server response', function(done) {
+          Author.all().then((response) => {
+            let called = Config.localStorage.setItem
+              .calledWith('jwt', 'somet0k3n');
+            expect(called).to.eq(true);
+            done();
+          });
+        });
+
+        it('uses the new jwt in subsequent requests', function(done) {
+          Author.all().then((response) => {
+            fetchMock.restore();
+
+            fetchMock.mock((url, opts) => {
+              expect(opts.headers.Authorization).to.eq('Token token="somet0k3n"')
+              done();
+              return true;
+            }, 200);
+            expect(Author.getJWT()).to.eq('somet0k3n');
+            expect(ApplicationRecord.jwt).to.eq('somet0k3n');
+            Author.all();
+          });
+        });
+
+        describe('when JWT is already in localStorage', function() {
+          beforeEach(function() {
+            fetchMock.restore();
+            Config.localStorage['getItem'] = sinon.stub().returns('myt0k3n');
+            configSetup({ jwtLocalStorage: 'jwt' });
+          });
+
+          afterEach(function() {
+            configSetup();
+          });
+
+          it('sends it in initial request', function(done) {
+            fetchMock.mock((url, opts) => {
+              expect(opts.headers.Authorization).to.eq('Token token="myt0k3n"')
+              done();
+              return true;
+            }, 200);
+            Author.find(1);
+          });
+        });
+      });
+
+      describe('when configured to NOT store jwt', function() {
+        beforeEach(function() {
+          Config.jwtLocalStorage = false;
+        });
+
+        it('is does NOT update localStorage on server response', function(done) {
+          Author.all().then((response) => {
+            let called = Config.localStorage.setItem.called;
+            expect(called).to.eq(false);
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  describe('a write request', function() {
+    beforeEach(function() {
+      fetchMock.mock({
+        matcher: '*',
+        response: {
+          status: 200,
+          body: { data: [] },
+          headers: {
+            'X-JWT': 'somet0k3n'
+          }
+        }
+      });
+    });
+
+    afterEach(function() {
+      fetchMock.restore();
+      ApplicationRecord.jwt = null;
+    });
+
+    it('also refreshes the jwt', function(done) {
+      let author = new Author({ firstName: 'foo' });
+      author.save().then(() => {
+        expect(ApplicationRecord.jwt).to.eq('somet0k3n');
+        done();
       });
     });
   });


### PR DESCRIPTION
If used from the browser, you can now get/set the JWT from localStorage:

```ts
Config.setup({
  jwtOwners: [...],
  jwtLocalStorage: 'jwt' // or whatever key you'd like to set
})
```

`jwtLocalStorage` is defaulted to `jwt`, meaning this functionality is
**opt-out**. Pass `false` to opt-out.

When enabled, this will automatically set the JWT via local storage, and
update it when the server contains the `X-JWT` header.