### PR TITLE
Add support for turning off attribute camelization

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -28,6 +28,7 @@ export default class Model {
   static isJWTOwner: boolean = false;
   static jwt: string = null;
   static parentClass: typeof Model;
+  static camelizeKeys: boolean = true;
 
   id: string;
   temp_id: string;
@@ -209,7 +210,12 @@ export default class Model {
 
   assignAttributes(attrs: Object) {
     for(var key in attrs) {
-      let attributeName = camelize(key);
+      let attributeName = key;
+
+      if (this.klass.camelizeKeys) {
+        attributeName = camelize(key);
+      }
+      
       if (key == 'id' || this.klass.attributeList[attributeName]) {
         this[attributeName] = attrs[key];
       }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -18,6 +18,12 @@ class PersonWithExtraAttr extends Person {
   extraThing: string = attr({ persist: false });
 }
 
+class PersonWithoutCamelizedKeys extends Person {
+  static camelizeKeys = false;
+
+  first_name: string = attr();
+}
+
 // Ensure setup() can be run multiple times with no problems
 // putting this here, otherwise relations wont be available.
 Config.setup();
@@ -95,6 +101,7 @@ export {
   Author,
   Person,
   PersonWithExtraAttr,
+  PersonWithoutCamelizedKeys,
   Book,
   Genre,
   Bio,

--- a/test/unit/attributes-test.ts
+++ b/test/unit/attributes-test.ts
@@ -1,5 +1,5 @@
 import { sinon, expect } from '../test-helper';
-import { Person, Author } from '../fixtures';
+import { Person, Author, PersonWithoutCamelizedKeys } from '../fixtures';
 
 describe('Model attributes', function() {
   it('supports direct assignment', function() {
@@ -19,6 +19,12 @@ describe('Model attributes', function() {
     let person = new Person({ first_name: 'Joe' });
     expect(person.firstName).to.eq('Joe');
   });
+
+  it('does not camlize underscored strings if camelization is disabled', function() {
+    let person = new PersonWithoutCamelizedKeys({ first_name: 'Joe' });
+    expect(person.firstName).to.eq(undefined);
+    expect(person.first_name).to.eq('Joe');
+  })
 
   it('syncs with #attributes', function() {
     let person = new Person();


### PR DESCRIPTION
Adds the `camelizeKeys` option. No breaking changes, as the default is `true`.

I branched off of #20 and I can rebase if/when that is merged to clean up this diff. 

This works (at least according to the tests) but if you have suggestions for a "better way" I am open to changing the implementation. 