### PR TITLE
Don't camelize relationship names when camelizeKeys is false

### DIFF
--- a/src/util/deserialize.ts
+++ b/src/util/deserialize.ts
@@ -159,7 +159,12 @@ class Deserializer {
 
   _iterateValidRelationships(instance, relationships, callback) {
     for (let key in relationships) {
-      let relationName = camelize(key);
+      let relationName = key;
+
+      if (instance.klass.camelizeKeys) {
+        relationName = camelize(key)
+      }
+
       if (instance.klass.attributeList[relationName]) {
         let relationData = relationships[key].data;
         if(!relationData) continue; // only links, empty, etc

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -35,7 +35,7 @@ let Author = Person.extend({
     jsonapiType: 'authors'
   },
 
-  nilly:      attr(),
+  nilly:        attr(),
 
   multiWords:   hasMany('multi_words'),
   specialBooks: hasMany('books'),
@@ -45,19 +45,36 @@ let Author = Person.extend({
   bio:          hasOne('bios')
 });
 
+let NonFictionAuthor = Author.extend({
+  static: {
+    endpoint: '/v1/non_fiction_authors',
+    jsonapiType: 'non_fiction_authors',
+    camelizeKeys: false
+  },
+
+  nilly:         attr(),
+
+  multi_words:   hasMany('multi_words'),
+  special_books: hasMany('books'),
+  books:         hasMany(),
+  tags:          hasMany(),
+  genre:         belongsTo('genres'),
+  bio:           hasOne('bios')
+});
+
 class Book extends ApplicationRecord {
   static jsonapiType = 'books';
 
   title: string = attr();
 
   genre = belongsTo('genres');
-  author = hasOne('authors')
+  author = hasOne('authors');
 }
 
 class Genre extends ApplicationRecord {
   static jsonapiType = 'genres';
 
-  authors: any = hasMany('authors')
+  authors: any = hasMany('authors');
 
   name: string = attr();
 }
@@ -65,32 +82,27 @@ class Genre extends ApplicationRecord {
 class Bio extends ApplicationRecord {
   static jsonapiType = 'bios';
 
-  description: string = attr()
+  description: string = attr();
 }
 
 class Tag extends ApplicationRecord {
   static jsonapiType = 'tags';
 
-  name: string = attr()
+  name: string = attr();
 }
 
 class MultiWord extends ApplicationRecord {
   static jsonapiType = 'multi_words';
 }
 
-const TestJWTSubclass = ApplicationRecord.extend({
-});
+const TestJWTSubclass = ApplicationRecord.extend({});
 
-const NonJWTOwner = Model.extend({
-});
+const NonJWTOwner = Model.extend({});
 
 const configSetup = function(opts = {}) {
-  opts['jwtOwners'] = [
-    ApplicationRecord,
-    TestJWTSubclass
-  ]
+  opts['jwtOwners'] = [ApplicationRecord, TestJWTSubclass];
   Config.setup(opts);
-}
+};
 configSetup();
 
 export {
@@ -99,6 +111,7 @@ export {
   TestJWTSubclass,
   NonJWTOwner,
   Author,
+  NonFictionAuthor,
   Person,
   PersonWithExtraAttr,
   PersonWithoutCamelizedKeys,

--- a/test/integration/relations-test.ts
+++ b/test/integration/relations-test.ts
@@ -1,0 +1,101 @@
+import { expect, fetchMock } from '../test-helper';
+import { Author, NonFictionAuthor } from '../fixtures';
+
+let resultData = function(promise) {
+  return promise.then(function(proxyObject) {
+    return proxyObject.data;
+  });
+};
+
+let generateMockResponse = function(type: string) {
+  return {
+    data: {
+      id: '1',
+      type: type,
+      attributes: {
+        firstName: 'John'
+      },
+      relationships: {
+        books: {
+          data: [
+            {
+              id: 'book1',
+              type: 'books'
+            }
+          ]
+        },
+        multi_words: {
+          data: [
+            {
+              id: 'multi_word1',
+              type: 'multi_words'
+            }
+          ]
+        }
+      }
+    },
+    included: [
+      {
+        id: 'book1',
+        type: 'books',
+        attributes: {
+          title: 'The Shining'
+        }
+      },
+      {
+        id: 'multi_word1',
+        type: 'multi_words',
+        attributes: {}
+      }
+    ]
+  };
+};
+
+describe('Relations', function() {
+  describe('#find()', function() {
+    beforeEach(function() {
+      fetchMock.get('http://example.com/api/v1/authors/1?include=books,multi_words', generateMockResponse('authors'));
+    });
+
+    afterEach(fetchMock.restore);
+
+    it('correctly includes relationships', function(done) {
+      resultData(Author.includes(['books', 'multi_words']).find(1)).then(data => {
+        expect(data.multiWords).to.be.an('array');
+        expect(data.books).to.be.an('array');
+
+        done();
+      });
+    });
+
+    it('contains the right records for each relationship', function(done) {
+      resultData(Author.includes(['books', 'multi_words']).find(1)).then(data => {
+        expect(data.books[0].title).to.eql('The Shining');
+        expect(data.multiWords[0].id).to.eql('multi_word1');
+
+        done();
+      });
+    });
+  });
+
+  describe('when camelizeKeys is false', function() {
+    beforeEach(function() {
+      fetchMock.get(
+        'http://example.com/api/v1/non_fiction_authors/1?include=books,multi_words',
+        generateMockResponse('non_fiction_authors')
+      );
+    });
+
+    afterEach(fetchMock.restore);
+
+    it("Doesn't convert relationships to snake_case if camelization is off", function(done) {
+      resultData(NonFictionAuthor.includes(['books', 'multi_words']).find(1))
+        .then(data => {
+          expect(data.multi_words[0].id).to.eql('multi_word1');
+
+          done();
+        })
+        .catch(done);
+    });
+  });
+});


### PR DESCRIPTION
I added some basic relationship tests in integration because I couldn't find a place that made sense for the camelize tests. Let me know if you know of a better location.

I followed the existing testing patterns as best I could, I hope they aren't too bad.