### PR TITLE
[Proposal] Make attributes enumerable

### DIFF
--- a/src/attribute.ts
+++ b/src/attribute.ts
@@ -51,11 +51,11 @@ export default class Attribute {
   }
 
   // This returns the getters/setters for use on the *model*
-  descriptor() {
+  descriptor(): PropertyDescriptor {
     let attr = this;
 
     return {
-      writeable: true,
+      enumerable: true,
       get() : any {
         return attr.getter(this);
       },

--- a/test/unit/attributes-test.ts
+++ b/test/unit/attributes-test.ts
@@ -47,6 +47,14 @@ describe('Model attributes', function() {
     expect(author.relationships['books']).to.deep.eq([])
   });
 
+  it('has enumerable properties', function() {
+    let person = new Person();
+    let keys = Object.keys(person)
+
+    expect(keys).to.include('firstName');
+    expect(keys).to.include('lastName');
+  });
+
   // Without this behavior, the API could add a backwards-compatible field,
   // and this object might blow up.
   describe('when passed an invalid attribute in constructor', function() {

--- a/test/unit/attributes-test.ts
+++ b/test/unit/attributes-test.ts
@@ -49,7 +49,17 @@ describe('Model attributes', function() {
 
   it('has enumerable properties', function() {
     let person = new Person();
-    let keys = Object.keys(person)
+    let keys = Object.keys(person);
+
+    expect(keys).to.include('firstName');
+    expect(keys).to.include('lastName');
+  });
+
+  it('has enumerable properties even when subclassing', function() {
+    class BadPerson extends Person {}
+
+    let badPerson = new BadPerson();
+    let keys = Object.keys(badPerson);
 
     expect(keys).to.include('firstName');
     expect(keys).to.include('lastName');

--- a/test/unit/relationships-test.ts
+++ b/test/unit/relationships-test.ts
@@ -33,4 +33,12 @@ describe('Model relationships', function() {
     let genre = new Genre();
     expect(genre.authors.length).to.eql(0);
   });
+
+  it('has enumerable properties', function() {
+    let genre = new Genre({ name: 'Horror' });
+    let author = new Author({ genre: genre });
+    let keys = Object.keys(author);
+
+    expect(keys).to.include('genre');
+  });
 });


### PR DESCRIPTION
This PR changes the descriptor for attributes to make them `enumerable`.

I'm opening it up for discussion because, while the diff itself is small, I think there are non-trivial implications.

#### Example Use Case

Tools like `normalizr` rely on [properties being enumerable](https://github.com/paularmstrong/normalizr/blob/master/src/schemas/Object.js#L5) when normalizing their data. This change enable these kinds of tools to work seamlessly since these objects now behave like regular old POJOs

---

NB: `writeable` is not spelled correctly, it's `writable`, (which is why that change is included in the diff). When I added the type annotation, TS immediately threw an error and when I corrected the spelling, tests started failing :(

[Here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) are the docs for `defineProperty`