### PR TITLE
Move to predictive temp IDs

### DIFF
--- a/src/util/temp-id.ts
+++ b/src/util/temp-id.ts
@@ -1,0 +1,7 @@
+let memo = 0
+const generate = function() : string {
+  memo++
+  return `temp-id-${memo}`
+}
+
+export default { generate }

--- a/src/util/uuid.ts
+++ b/src/util/uuid.ts
@@ -1,8 +1,0 @@
-const generate = function() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-    let r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
-    return v.toString(16);
-  });
-}
-
-export default { generate };

--- a/src/util/write-payload.ts
+++ b/src/util/write-payload.ts
@@ -1,7 +1,7 @@
 import Model from '../model';
 import IncludeDirective from './include-directive';
 import * as _snakeCase from './snakecase';
-import uuid from './uuid';
+import tempId from './temp-id';
 let snakeCase: any = (<any>_snakeCase).default || _snakeCase;
 snakeCase = snakeCase['default'] || snakeCase;
 
@@ -134,7 +134,7 @@ export default class WritePayload {
     model.clearErrors();
 
     if (!model.isPersisted()) {
-      model.temp_id = uuid.generate();
+      model.temp_id = tempId.generate()
     }
 
     let wp            = new WritePayload(model, nested);

--- a/test/integration/nested-persistence-test.ts
+++ b/test/integration/nested-persistence-test.ts
@@ -1,6 +1,6 @@
 import { sinon, expect, fetchMock } from '../test-helper';
 import { Author, Book, Genre } from '../fixtures';
-import uuid from '../../src/util/uuid';
+import tempId from '../../src/util/temp-id';
 
 let fetchMock = require('fetch-mock');
 
@@ -184,7 +184,7 @@ describe('nested persistence', function() {
 
   let tempIdIndex = 0;
   beforeEach(function() {
-    sinon.stub(uuid, 'generate').callsFake(function() {
+    sinon.stub(tempId, 'generate').callsFake(function() {
       tempIdIndex++
       return `abc${tempIdIndex}`;
     });
@@ -192,7 +192,7 @@ describe('nested persistence', function() {
 
   afterEach(function() {
     tempIdIndex = 0;
-    uuid.generate['restore']();
+    tempId.generate['restore']();
   });
 
   describe('basic nested create', function() {

--- a/test/integration/validations-test.ts
+++ b/test/integration/validations-test.ts
@@ -1,6 +1,6 @@
 import { expect, sinon, fetchMock } from '../test-helper';
 import { Author, Book, Genre } from '../fixtures';
-import uuid from '../../src/util/uuid';
+import tempId from '../../src/util/temp-id';
 
 const resetMocks = function() {
   fetchMock.restore();
@@ -94,7 +94,7 @@ describe('validations', function() {
   });
 
   beforeEach(function() {
-    sinon.stub(uuid, 'generate').callsFake(function() {
+    sinon.stub(tempId, 'generate').callsFake(function() {
       tempIdIndex++
       return `abc${tempIdIndex}`;
     });
@@ -108,7 +108,7 @@ describe('validations', function() {
 
   afterEach(function() {
     tempIdIndex = 0;
-    uuid.generate['restore']();
+    tempId.generate['restore']();
   });
 
   it('applies errors to the instance', function(done) {


### PR DESCRIPTION
Temp IDs don't have to actually be unique - they just have to match up
the relationships/included sections of the payload, and serve as a
reference to an unpersisted object on the client. They should be unique,
not universally or globally unique.

Because of this, let's generate more predictive, simpler temp IDs. This
improves readability, and avoids mocking difficulties.