### PR TITLE
Add fetch middleware; improve promise handling

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -17,6 +17,8 @@ export default class Config {
   static logger: Logger = new Logger();
   static jwtLocalStorage: string | false = 'jwt';
   static localStorage;
+  static beforeFetch: Array<Function> = []
+  static afterFetch: Array<Function> = []
 
   static setup(options? : Object) : void {
     if (!options) options = {};

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,7 +1,40 @@
 import Config from './configuration';
+import Model from './model';
 import colorize from './util/colorize';
+import patchExtends from './custom-extend';
+patchExtends()
+
+class RequestError extends Error {
+  url: string
+  options: RequestInit
+  originalError: Error
+
+  constructor(message: string, url: string, options: RequestInit, originalError: Error) {
+    super(message)
+    this.url = url
+    this.options = options
+    this.originalError = originalError
+  }
+}
+
+class ResponseError extends Error {
+  response: Response
+  originalError: Error
+
+  constructor(response: Response | null, message?: string, originalError?: Error) {
+    super(message || 'Invalid Response')
+    this.response = response
+    this.originalError = originalError
+  }
+}
 
 export default class Request {
+  modelClass: typeof Model
+
+  constructor(modelClass: typeof Model) {
+    this.modelClass = modelClass
+  }
+
   get(url : string, options: RequestInit) : Promise<any> {
     options.method = 'GET';
     return this._fetchWithLogging(url, options);
@@ -39,23 +72,54 @@ export default class Request {
   private _fetchWithLogging(url: string, options: RequestInit) : Promise<any> {
     this._logRequest(options.method, url);
     let promise = this._fetch(url, options);
-    promise.then((response : any) => {
+    return promise.then((response : any) => {
       this._logResponse(response['jsonPayload']);
+      return response
     });
-    return promise;
   }
 
   private _fetch(url: string, options: RequestInit) : Promise<any> {
     return new Promise((resolve, reject) => {
+      try {
+        this.modelClass.beforeFetch(url, options)
+      } catch(e) {
+        reject(new RequestError('beforeFetch failed; review Config.beforeFetch', url, options, e))
+      }
+
       let fetchPromise = fetch(url, options);
       fetchPromise.then((response) => {
-        response.json().then((json) => {
-          response['jsonPayload'] = json;
-          resolve(response);
-        }).catch((e) => { throw(e); });
+        this._handleResponse(response, resolve, reject)
       });
 
-      fetchPromise.catch(reject);
+      fetchPromise.catch((e) => {
+        // Fetch itself failed (usually network error)
+        reject(new ResponseError(null, e.message, e))
+      })
+    });
+  }
+
+  private _handleResponse(response: Response, resolve: Function, reject: Function) : void {
+    response.json().then((json) => {
+      try {
+        this.modelClass.afterFetch(response, json)
+      } catch(e) {
+        // afterFetch middleware failed
+        reject(new ResponseError(response, 'afterFetch failed; review Config.afterFetch', e))
+      }
+
+      if (response.status >= 500) {
+        reject(new ResponseError(response, 'Server Error'))
+      } else if (response.status !== 422 && json['data'] === undefined) {
+        // Bad JSON, for instance an errors payload
+        // Allow 422 since we specially handle validation errors
+        reject(new ResponseError(response, 'invalid json'))
+      }
+
+      response['jsonPayload'] = json;
+      resolve(response);
+    }).catch((e) => {
+      // The response was probably not in JSON format
+      reject(new ResponseError(response, 'invalid json', e))
     });
   }
 }

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -29,7 +29,7 @@ export default class Scope {
     return this._fetch(this.model.url()).then((json : japiDoc) => {
       let collection = new CollectionProxy<Model>(json);
       return collection;
-    });
+    })
   }
 
   find(id : string | number) : Promise<RecordProxy<Model>> {
@@ -215,16 +215,16 @@ export default class Scope {
   }
 
   private _fetch(url : string) : Promise<Object> {
-    let qp = this.toQueryParams();
+    let qp = this.toQueryParams()
     if (qp) {
-      url = `${url}?${qp}`;
+      url = `${url}?${qp}`
     }
-    let request = new Request();
+    let request = new Request(this.model)
     let fetchOpts = this.model.fetchOptions()
-
-    return request.get(url, fetchOpts).then((response) => {
-      refreshJWT(this.model, response);
-      return response['jsonPayload'];
-    });
+    let promise = request.get(url, fetchOpts)
+    return promise.then((response) => {
+      refreshJWT(this.model, response)
+      return response['jsonPayload']
+    })
   }
 }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -106,6 +106,7 @@ const configSetup = function(opts = {}) {
 configSetup();
 
 export {
+  Config,
   configSetup,
   ApplicationRecord,
   TestJWTSubclass,

--- a/test/integration/fetch-middleware-test.ts
+++ b/test/integration/fetch-middleware-test.ts
@@ -1,0 +1,364 @@
+import { expect, sinon, fetchMock } from '../test-helper';
+import { Author, Config } from '../fixtures';
+
+const mock401 = function() {
+  fetchMock.restore();
+
+  fetchMock.mock({
+    matcher: '*',
+    response: {
+      status: 401,
+      body: {
+        errors: [
+          {
+            code: 'unauthenticated',
+            status: '401',
+            title: 'Authentication Error',
+            detail: 'You must sign in to access this resource',
+            meta: { }
+          }
+        ]
+      }
+    }
+  })
+}
+
+const mockBadJSON = function() {
+  fetchMock.restore();
+
+  fetchMock.mock({
+    matcher: '*',
+    response: {
+      status: 500,
+      body: undefined
+    }
+  })
+}
+
+const mock500 = function() {
+  fetchMock.restore();
+
+  fetchMock.mock({
+    matcher: '*',
+    response: {
+      status: 500,
+      body: {
+        errors: []
+      }
+    }
+  })
+}
+
+const mockSuccess = function() {
+  fetchMock.restore();
+
+  fetchMock.mock({
+    matcher: '*',
+    response: {
+      status: 200,
+      body: {
+        data: []
+      }
+    }
+  })
+}
+
+
+let before = {} as any
+let after = {} as any
+describe('fetch middleware', function() {
+  beforeEach(function () {
+    mockSuccess();
+
+    Config.beforeFetch.push(function(url, options) {
+      before = { url, options }
+
+      // Author.first, or saving author with name 'abortme'
+      // should abort
+      let shouldAbort = false
+      if (url.indexOf('page') > -1) shouldAbort = true
+      if (options.body && options.body.indexOf('abortme') > -1) {
+        shouldAbort = true
+      }
+
+      if (shouldAbort) {
+        throw('abort')
+      }
+    })
+
+    Config.afterFetch.push(function(response, json) {
+      after = { response, json }
+
+      if (response.status == 401) {
+        throw('abort')
+      }
+    })
+  });
+
+  afterEach(function() {
+    fetchMock.restore()
+    Config.beforeFetch = []
+    Config.afterFetch = []
+    before = {}
+    after = {}
+  })
+
+  describe('reads', function() {
+    describe('on successful response', function() {
+      it('correctly resolves the promise', function() {
+        return Author.all().then(({data}) => {
+          expect(data).to.deep.eq([])
+        })
+      })
+
+      it('runs beforeEach hooks', function() {
+        return Author.all().then(({data}) => {
+          expect(before.url).to.eq('http://example.com/api/v1/authors')
+          expect(before.options).to.deep.eq({
+            headers: {
+              Accept: 'application/json',
+              'Content-Type': 'application/json'
+            },
+            method: 'GET'
+          })
+        })
+      })
+
+      it('runs afterEach hooks', function() {
+        return Author.all().then(({data}) => {
+          expect(after.response.status).to.eq(200)
+        })
+      })
+    })
+
+    describe('when beforeFetch middleware aborts', function() {
+      beforeEach(function() {
+        mockSuccess()
+      })
+
+      it('rejects the promise w/correct RequestError class', function() {
+        return Author.first().then(({data}) => {
+          expect('dont get here!').to.eq(true)
+        })
+        .catch((e) => {
+          expect(e.message).to
+            .eq('beforeFetch failed; review Config.beforeFetch')
+          expect(e.originalError).to.eq('abort')
+          expect(e.url).to.eq('http://example.com/api/v1/authors?page[size]=1')
+        })
+      })
+    })
+
+    describe('when afterFetch middleware aborts', function() {
+      beforeEach(function() {
+        mock401()
+      })
+
+      it('rejects the promise w/correct ResponseError class', function() {
+        return Author.all().then(({data}) => {
+          expect('dont get here!').to.eq(true)
+        })
+        .catch((e) => {
+          expect(e.message).to
+            .eq('afterFetch failed; review Config.afterFetch')
+          expect(e.response.status).to.eq(401)
+          expect(e.originalError).to.eq('abort')
+        })
+      })
+    })
+
+    describe('on 500 response', function() {
+      beforeEach(function() {
+        mock500()
+      })
+
+      it('rejects the promise with the response', function() {
+        return Author.all().then(({data}) => {
+          expect('dont get here!').to.eq(true)
+        })
+        .catch((e) => {
+          expect(e.response.statusText).to.eq('Internal Server Error')
+        })
+      })
+    })
+
+    describe('on bad json response', function() {
+      beforeEach(function() {
+        mockBadJSON()
+      })
+
+      it('rejects the promise with original error', function() {
+        return Author.all().then(({data}) => {
+          expect('dont get here!').to.eq(true)
+        })
+        .catch((e) => {
+          expect(e.response.statusText).to.eq('Internal Server Error')
+          expect(e.originalError.message)
+            .to.eq('Unexpected end of JSON input')
+        })
+      })
+    })
+
+    describe('when the model overrides the hooks', function() {
+      let originalBeforeFetch;
+      let originalAfterFetch;
+
+      beforeEach(function() {
+        originalBeforeFetch = Author.beforeFetch
+        originalAfterFetch = Author.afterFetch
+
+        Author.beforeFetch = function(url, options) {
+          before.overridden = true
+        }
+
+        Author.afterFetch = function(url, options) {
+          after.overridden = true
+        }
+      })
+
+      afterEach(function() {
+        Author.beforeFetch = originalBeforeFetch
+        Author.afterFetch = originalAfterFetch
+      })
+
+      it('uses the override', function() {
+        Author.all().then(() => {
+          expect(before).to.deep.eq({ overridden: true })
+          expect(after).to.deep.eq({ overridden: true })
+        })
+      })
+    })
+  })
+
+  describe('writes', function() {
+    describe('on successful response', function() {
+      it('correctly resolves the promise', function() {
+        let author = new Author()
+        return author.save().then((success) => {
+          expect(success).to.eq(true)
+        })
+      })
+
+      it('runs beforeEach hooks', function() {
+        let author = new Author()
+        return author.save().then(() => {
+          expect(before.url).to.eq('http://example.com/api/v1/authors')
+          expect(before.options).to.deep.eq({
+            headers: {
+              Accept: 'application/json',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ data: { type: 'authors' } }),
+            method: 'POST'
+          })
+        })
+      })
+
+      it('runs afterEach hooks', function() {
+        let author = new Author()
+        return author.save().then(() => {
+          expect(after.response.status).to.eq(200)
+        })
+      })
+    })
+
+    describe('when beforeFetch middleware aborts', function() {
+      it('rejects the promise w/correct RequestError class', function() {
+        let author = new Author({ firstName: 'abortme' })
+        return author.save().then(() => {
+          expect('dont get here!').to.eq(true)
+        })
+        .catch((e) => {
+          expect(e.message).to
+            .eq('beforeFetch failed; review Config.beforeFetch')
+          expect(e.originalError).to.eq('abort')
+          expect(e.url).to.eq('http://example.com/api/v1/authors')
+        })
+      })
+    })
+
+    describe('when afterFetch middleware aborts', function() {
+      beforeEach(function() {
+        mock401()
+      })
+
+      it('rejects the promise w/correct ResponseError class', function() {
+        let author = new Author()
+        return author.save().then(() => {
+          expect('dont get here!').to.eq(true)
+        })
+        .catch((e) => {
+          expect(e.message).to
+            .eq('afterFetch failed; review Config.afterFetch')
+          expect(e.response.status).to.eq(401)
+          expect(e.originalError).to.eq('abort')
+        })
+      })
+    })
+
+    describe('on 500 response', function() {
+      beforeEach(function() {
+        mock500()
+      })
+
+      it('rejects the promise with the response', function() {
+        let author = new Author()
+        return author.save().then(() => {
+          expect('dont get here!').to.eq(true)
+        })
+        .catch((e) => {
+          expect(e.response.statusText).to.eq('Internal Server Error')
+        })
+      })
+    })
+
+    describe('on bad json response', function() {
+      beforeEach(function() {
+        mockBadJSON()
+      })
+
+      it('rejects the promise with original error', function() {
+        let author = new Author()
+        return author.save().then(() => {
+          expect('dont get here!').to.eq(true)
+        })
+        .catch((e) => {
+          expect(e.response.statusText).to.eq('Internal Server Error')
+          expect(e.originalError.message)
+            .to.eq('Unexpected end of JSON input')
+        })
+      })
+    })
+
+    describe('when the model overrides the hooks', function() {
+      let originalBeforeFetch;
+      let originalAfterFetch;
+
+      beforeEach(function() {
+        originalBeforeFetch = Author.beforeFetch
+        originalAfterFetch = Author.afterFetch
+
+        Author.beforeFetch = function(url, options) {
+          before.overridden = true
+        }
+
+        Author.afterFetch = function(url, options) {
+          after.overridden = true
+        }
+      })
+
+      afterEach(function() {
+        Author.beforeFetch = originalBeforeFetch
+        Author.afterFetch = originalAfterFetch
+      })
+
+      it('uses the override', function() {
+        let author = new Author()
+        author.save().then(() => {
+          expect(before).to.deep.eq({ overridden: true })
+          expect(after).to.deep.eq({ overridden: true })
+        })
+      })
+    })
+  })
+})

--- a/test/integration/persistence-test.ts
+++ b/test/integration/persistence-test.ts
@@ -188,7 +188,7 @@ describe('Model persistence', function() {
 
         it('rejects the promise', function(done) {
           instance.save().catch((err) => {
-            expect(err).to.eq('Server Error');
+            expect(err.message).to.eq('Server Error');
             done();
           });
         });
@@ -304,7 +304,7 @@ describe('Model persistence', function() {
 
       it('rejects the promise', function() {
         instance.destroy().catch((err) => {
-          expect(err).to.eq('Server Error');
+          expect(err.message).to.eq('Server Error');
         });
       });
     });


### PR DESCRIPTION
This is for things like "on any unauthenticated request, redirect to the
login page". You can now add before/after fetch hooks:

```ts
Config.beforeFetch.push(function(url, options) {
  options.headers['some-new-header'] = 'foo'
})

Config.afterFetch.push(function(response, json) {
  if (response.status === 401) {
    throw('abort')
  }
})
```

Throwing `abort` will reject the promises as *all* promises are now
rejected: by throwing a RequestError or ResponseError class. These
classes have additional info (like the response object) on them for
additional introspection/handling.

```ts
author.save().catch((e) => {
  console.log(e.response.status);
})
```

Finally, this behavior can be overridden at the model level:

```ts
static beforeFetch(url: RequestInfo, options: RequestInit) {
 // your overrides here
 // call super if you want the Config hooks to run as well
}

static afterFetch(response: Response, json: JSON) {
 // your overrides here
 // call super if you want the Config hooks to run as well
}
```