### PR TITLE
Add stricter comparison between global and window objects.

### DIFF
--- a/src/custom-extend.ts
+++ b/src/custom-extend.ts
@@ -3,7 +3,7 @@
 // Allows 'inherited' hook
 
 let globalObj;
-if (typeof window === 'undefined') {
+if (typeof window === 'undefined' || window != (global as any)) {
   globalObj = global;
 } else {
   globalObj = window;

--- a/src/util/extend.ts
+++ b/src/util/extend.ts
@@ -2,7 +2,7 @@
 // use for non-typescript extends
 
 let globalObj;
-if (typeof window === 'undefined') {
+if (typeof window === 'undefined' || window !== (global as any)) {
   globalObj = global;
 } else {
   globalObj = window;


### PR DESCRIPTION
Supports js-dom and faked DOM environments during Node testing. See https://github.com/jsonapi-suite/jsorm/issues/31 for more context.

Thanks to @wadetandy and @richmolj for their help with this.