### PR TITLE
#35 fixed tests in 5.3

### DIFF
--- a/test/integration/fetch-middleware-test.ts
+++ b/test/integration/fetch-middleware-test.ts
@@ -194,7 +194,7 @@ describe('fetch middleware', function() {
         .catch((e) => {
           expect(e.response.statusText).to.eq('Internal Server Error')
           expect(e.originalError.message)
-            .to.eq('Unexpected end of JSON input')
+            .to.contain('Unexpected end of JSON input')
         })
       })
     })
@@ -325,7 +325,7 @@ describe('fetch middleware', function() {
         .catch((e) => {
           expect(e.response.statusText).to.eq('Internal Server Error')
           expect(e.originalError.message)
-            .to.eq('Unexpected end of JSON input')
+            .to.contain('Unexpected end of JSON input')
         })
       })
     })

--- a/test/unit/model-test.ts
+++ b/test/unit/model-test.ts
@@ -133,7 +133,7 @@ describe('Model', function() {
       expect(ApplicationRecord.jwt).to.eq('n3wt0k3n');
     });
 
-    describe.only('when localStorage is configured', function() {
+    describe('when localStorage is configured', function() {
       beforeEach(function() {
         Config.jwtLocalStorage = 'jwt'
         Config.localStorage = { setItem: sinon.spy() }


### PR DESCRIPTION
* on `integration/fetch-middleware-test.ts` removed `.only` so all the tests are ran.
* on `unit/model-test` the actual error message was: `'invalid json response body at http://example.com/api/v1/authors reason: Unexpected end of JSON input'`, so sing contain to have a really _generic_ matcher for the expectation.
  