### PR TITLE
Ensure relationship keys are de-camelized in write payload

### DIFF
--- a/src/util/string.ts
+++ b/src/util/string.ts
@@ -6,4 +6,8 @@ const camelize = function(str) {
   return str.replace(/(\_[a-z])/g, function($1){return $1.toUpperCase().replace('_','');});
 }
 
-export { underscore, camelize };
+const decamelize = function(str) {
+  return str.replace(/([A-Z])/g, function($1){return $1.replace($1,'_' + $1).toLowerCase();});
+}
+
+export { underscore, camelize, decamelize };

--- a/src/util/write-payload.ts
+++ b/src/util/write-payload.ts
@@ -2,6 +2,7 @@ import Model from '../model';
 import IncludeDirective from './include-directive';
 import * as _snakeCase from './snakecase';
 import tempId from './temp-id';
+import { decamelize } from './string';
 let snakeCase: any = (<any>_snakeCase).default || _snakeCase;
 snakeCase = snakeCase['default'] || snakeCase;
 
@@ -87,7 +88,7 @@ export default class WritePayload {
         }
 
         if (data) {
-          _relationships[key] = { data }
+          _relationships[decamelize(key)] = { data }
         }
       }
     });

--- a/test/integration/nested-persistence-test.ts
+++ b/test/integration/nested-persistence-test.ts
@@ -233,7 +233,7 @@ describe('nested persistence', function() {
     // todo remove #destroy? and just save when markwithpersisted? combo? for ombined payload
     // todo test unique includes/circular relationshio
     it('sends the correct payload', function(done) {
-      instance.save({ with: { books: 'genre', specialBooks: true } }).then((response) => {
+      instance.save({ with: { books: 'genre', specialBooks: {} } }).then((response) => {
         expect(payloads[0]).to.deep.equal(expectedCreatePayload);
         done();
       });

--- a/test/integration/nested-persistence-test.ts
+++ b/test/integration/nested-persistence-test.ts
@@ -42,6 +42,15 @@ let expectedCreatePayload =  {
             method: 'create'
           }
         ]
+      },
+      special_books: {
+        data: [
+          {
+            ['temp-id']: 'abc3',
+            type: 'books',
+            method: 'create'
+          }
+        ]
       }
     }
   },
@@ -67,6 +76,13 @@ let expectedCreatePayload =  {
       type: 'genres',
       attributes: {
         name: 'Horror'
+      }
+    },
+    {
+      ['temp-id']: 'abc3',
+      type: 'books',
+      attributes: {
+        title: 'The Stand'
       }
     }
   ]
@@ -122,8 +138,11 @@ const seedPersistedData = function() {
   genre.isPersisted(true);
   let book = new Book({ id: '10', title: 'The Shining', genre: genre });
   book.isPersisted(true);
+  let specialBook = new Book({ id: '30', title: 'The Stand' });
+  specialBook.isPersisted(true);
   instance.id = '1';
   instance.books = [book];
+  instance.specialBooks = [specialBook];
   instance.isPersisted(true);
   genre.name = 'Updated Genre Name';
   book.title = 'Updated Book Title';
@@ -169,6 +188,12 @@ describe('nested persistence', function() {
           id: '20',
           type: 'genres',
           attributes: { name: 'name from server' }
+        },
+        {
+          ['temp-id']: 'abc3',
+          id: '30',
+          type: 'books',
+          attributes: { title: 'anothertitle from server' }
         }
       ]
     }
@@ -199,15 +224,18 @@ describe('nested persistence', function() {
     beforeEach(function() {
       let genre = new Genre({ name: 'Horror' });
       let book = new Book({ title: 'The Shining', genre: genre });
+      let specialBook = new Book({ title: 'The Stand' });
       instance.books = [book];
+      instance.specialBooks = [specialBook];
     });
 
     // todo test on the way back - id set, attrs updated, isPersisted
     // todo remove #destroy? and just save when markwithpersisted? combo? for ombined payload
     // todo test unique includes/circular relationshio
     it('sends the correct payload', function(done) {
-      instance.save({ with: { books: 'genre' } }).then((response) => {
+      instance.save({ with: { books: 'genre', specialBooks: true } }).then((response) => {
         expect(payloads[0]).to.deep.equal(expectedCreatePayload);
+        // expect(JSON.stringify(payloads[0])).to.equal(JSON.stringify(expectedCreatePayload));
         done();
       });
     });

--- a/test/integration/nested-persistence-test.ts
+++ b/test/integration/nested-persistence-test.ts
@@ -193,7 +193,7 @@ describe('nested persistence', function() {
           ['temp-id']: 'abc3',
           id: '30',
           type: 'books',
-          attributes: { title: 'anothertitle from server' }
+          attributes: { title: 'another title from server' }
         }
       ]
     }
@@ -235,7 +235,6 @@ describe('nested persistence', function() {
     it('sends the correct payload', function(done) {
       instance.save({ with: { books: 'genre', specialBooks: true } }).then((response) => {
         expect(payloads[0]).to.deep.equal(expectedCreatePayload);
-        // expect(JSON.stringify(payloads[0])).to.equal(JSON.stringify(expectedCreatePayload));
         done();
       });
     });


### PR DESCRIPTION
We're seeing an issue where a multi-word relationship key (in Rails) is receiving a write payload with a camelized key. The write fails in this case:

```js
{
  data: {
    id: "1",
    relationships: {
      specialBooks: {
        data: {} // etc
      }
    }
}
```

This PR adds a test for this behavior, and introduces the `decamelize` string helper.

Definitely open to more elegant ways to do this without decamelizing a string!