### PR TITLE
Ensure singular calls always resolve a record

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,29 @@
-export { 
-  JSORMBase 
+export {
+  JSORMBase
 } from './model';
 
-export { 
-  Attribute, 
-  attr 
+export {
+  Attribute,
+  attr
 } from './attribute';
 
-export { 
-  hasMany, 
-  hasOne, 
-  belongsTo 
+export {
+  hasMany,
+  hasOne,
+  belongsTo
 } from './associations';
 
-export { 
-  Model, 
+export {
+  Model,
   Attr,
   HasMany,
   HasOne,
   BelongsTo,
 } from './decorators'
+
+export {
+  MiddlewareStack
+} from './middleware-stack'
 
 export {
   Scope,

--- a/src/jsonapi-spec.ts
+++ b/src/jsonapi-spec.ts
@@ -1,4 +1,5 @@
 export type JsonapiResponseDoc = JsonapiCollectionDoc | JsonapiResourceDoc | JsonapiErrorDoc
+export type JsonapiSuccessDoc = JsonapiCollectionDoc | JsonapiResourceDoc
 export type JsonapiRequestDoc  = JsonapiResourceRequest
 
 export interface JsonapiDocMeta {
@@ -12,7 +13,7 @@ export interface JsonapiCollectionDoc extends JsonapiDocMeta {
 }
 
 export interface JsonapiResourceDoc extends JsonapiDocMeta {
-  data?: JsonapiResource | undefined
+  data: JsonapiResource
   errors?: undefined
 }
 

--- a/src/proxies/record-proxy.ts
+++ b/src/proxies/record-proxy.ts
@@ -4,10 +4,10 @@ import { JsonapiResponseDoc } from '../jsonapi-spec'
 
 export class RecordProxy<T extends JSORMBase> implements IResultProxy<T> {
   private _raw_json : JsonapiResponseDoc;
-  private _record : T | null;
+  private _record : T;
 
-  constructor (record : T | undefined | null, raw_json : JsonapiResponseDoc) {
-    this._record = (record || null)
+  constructor (record : T, raw_json : JsonapiResponseDoc) {
+    this._record = record
     this._raw_json = raw_json;
   }
 
@@ -15,7 +15,7 @@ export class RecordProxy<T extends JSORMBase> implements IResultProxy<T> {
     return this._raw_json;
   }
 
-  get data () : T | null {
+  get data () : T {
     return this._record;
   }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,7 +1,7 @@
 import colorize from './util/colorize';
 import { MiddlewareStack } from './middleware-stack';
 import { ILogger, logger as defaultLogger } from './logger';
-import { 
+import {
   JsonapiResponseDoc,
   JsonapiRequestDoc
 } from './jsonapi-spec'
@@ -103,10 +103,14 @@ export class Request {
 
     if (response.status >= 500) {
       throw new ResponseError(response, 'Server Error')
-    } else if (response.status !== 422 && json['data'] === undefined) {
-      // Bad JSON, for instance an errors payload
       // Allow 422 since we specially handle validation errors
-      throw new ResponseError(response, 'invalid json')
+    } else if (response.status !== 422 && json['data'] === undefined) {
+      if (response.status === 404) {
+        throw new ResponseError(response, 'record not found')
+      } else {
+        // Bad JSON, for instance an errors payload
+        throw new ResponseError(response, 'invalid json')
+      }
     }
 
     ;(<any>response)['jsonPayload'] = json;

--- a/test/integration/relations.test.ts
+++ b/test/integration/relations.test.ts
@@ -49,7 +49,7 @@ let generateMockResponse = function(type: string) {
         attributes: {}
       }
     ]
-  };
+  } as any
 };
 
 describe('Relations', function() {
@@ -77,6 +77,21 @@ describe('Relations', function() {
         done();
       });
     });
+
+    describe('when a belongsTo relationship has null data', function() {
+      beforeEach(function() {
+        let response = generateMockResponse('authors')
+        response.data.relationships = { genre: { data: null } }
+        delete response.data.included
+        fetchMock.get('http://example.com/api/v1/authors/1?include=genre', response)
+      })
+
+      it('does not blow up', async function() {
+        let { data } = await Author.includes(['genre']).find(1)
+        expect(data.klass).to.eq(Author)
+        expect(data.genre).to.eq(undefined)
+      })
+    })
   });
 
   describe('when camelizeKeys is false', function() {

--- a/test/unit/record-proxy.test.ts
+++ b/test/unit/record-proxy.test.ts
@@ -45,21 +45,6 @@ describe('RecordProxy', function() {
       let record = new RecordProxy(modelRecord, personData)
       expect(record.data).to.be.instanceof(Person)
     })
-
-    context('record is null is null', function() {
-      beforeEach(() => {
-        personData = {
-          data: undefined
-        }
-
-        modelRecord = undefined
-      })
-
-      it('should assign data to null', function() {
-        let record = new RecordProxy(modelRecord, personData)
-        expect(record.data).to.eq(null)
-      })
-    })
   })
 
   describe('#meta', function() {


### PR DESCRIPTION
Previously the `response.data` of a `Person.find(1).then((response))`
call could be a `Person` instance or null. This is valid according to
the spec, but not helpful for actual development.

Instead, we reject the promise with a relevant error message if the
response is 404 or if `data` is `null`. This way we can have confidence
a successful promise always has not-null `data`