### PR TITLE
Handle Model.first() when result set is empty

### DIFF
--- a/src/proxies/index.ts
+++ b/src/proxies/index.ts
@@ -1,5 +1,6 @@
 export { CollectionProxy } from "./collection-proxy"
 export { RecordProxy } from "./record-proxy"
+export { NullProxy } from "./null-proxy"
 import { JsonapiResponseDoc } from "../jsonapi-spec"
 
 export interface IResultProxy<T> {

--- a/src/proxies/null-proxy.ts
+++ b/src/proxies/null-proxy.ts
@@ -1,0 +1,22 @@
+import { JsonapiResponseDoc } from "../jsonapi-spec"
+import { IResultProxy } from "./index"
+
+export class NullProxy implements IResultProxy<null> {
+  private _raw_json: JsonapiResponseDoc
+
+  constructor(raw_json: JsonapiResponseDoc) {
+    this._raw_json = raw_json
+  }
+
+  get raw(): JsonapiResponseDoc {
+    return this._raw_json
+  }
+
+  get data() {
+    return null
+  }
+
+  get meta(): Record<string, any> {
+    return this.raw.meta || {}
+  }
+}


### PR DESCRIPTION
Previously calling first() when the result set was empty caused
everything to blow up.  This instead returns a NullProxy object.

Fixes #49 