### PR TITLE
Rename localStorge => credentialStorage

### DIFF
--- a/src/credential-storage.ts
+++ b/src/credential-storage.ts
@@ -25,7 +25,7 @@ try {
   defaultBackend = new NullStorageBackend()
 }
 
-export class LocalStorage {
+export class CredentialStorage {
   private _jwtKey: string | false
   private _backend: StorageBackend
 

--- a/test/integration/authorization.test.ts
+++ b/test/integration/authorization.test.ts
@@ -150,7 +150,7 @@ describe("authorization headers", () => {
     })
 
     describe("local storage", () => {
-      let localStorageMock: {
+      let credentialStorageMock: {
         getItem: SinonSpy
         setItem: SinonSpy
         removeItem: SinonSpy
@@ -163,31 +163,31 @@ describe("authorization headers", () => {
         ;(<any>ApplicationRecord) = null
         ;(<any>Author) = null
 
-        localStorageMock = {
+        credentialStorageMock = {
           setItem: sinon.spy(),
           getItem: sinon.spy(),
           removeItem: sinon.spy()
         }
-        JSORMBase.localStorageBackend = localStorageMock
+        JSORMBase.credentialStorageBackend = credentialStorageMock
       })
 
       afterEach(() => {
-        JSORMBase.localStorageBackend = undefined as any
-        JSORMBase.jwtLocalStorage = false
+        JSORMBase.credentialStorageBackend = undefined as any
+        JSORMBase.jwtStorage = false
       })
 
       describe("when configured to store jwt", () => {
-        describe("when JWT is not in localStorage", () => {
+        describe("when JWT is not in credentialStorage", () => {
           beforeEach(() => {
-            JSORMBase.jwtLocalStorage = "jwt"
+            JSORMBase.jwtStorage = "jwt"
 
             buildModels()
           })
 
-          it("updates localStorage on server response", async () => {
+          it("updates credentialStorage on server response", async () => {
             await Author.all()
 
-            expect(localStorageMock.setItem).to.have.been.calledWith(
+            expect(credentialStorageMock.setItem).to.have.been.calledWith(
               "jwt",
               "somet0k3n"
             )
@@ -213,11 +213,11 @@ describe("authorization headers", () => {
           })
         })
 
-        describe("when JWT is already in localStorage", () => {
+        describe("when JWT is already in credentialStorage", () => {
           beforeEach(() => {
-            JSORMBase.jwtLocalStorage = "jwt"
+            JSORMBase.jwtStorage = "jwt"
             fetchMock.restore()
-            JSORMBase.localStorage.getJWT = sinon.stub().returns("myt0k3n")
+            JSORMBase.credentialStorage.getJWT = sinon.stub().returns("myt0k3n")
 
             buildModels()
           })
@@ -240,15 +240,15 @@ describe("authorization headers", () => {
 
       describe("when configured to NOT store jwt", () => {
         beforeEach(() => {
-          JSORMBase.jwtLocalStorage = false
+          JSORMBase.jwtStorage = false
 
           buildModels()
         })
 
-        it("is does NOT update localStorage on server response", async () => {
+        it("is does NOT update credentialStorage on server response", async () => {
           await Author.all()
 
-          expect(localStorageMock.setItem).not.to.have.been.called
+          expect(credentialStorageMock.setItem).not.to.have.been.called
         })
       })
     })

--- a/test/unit/model.test.ts
+++ b/test/unit/model.test.ts
@@ -3,7 +3,7 @@ import { JSORMBase } from "../../src/model"
 import { hasOne } from "../../src/associations"
 import { attr } from "../../src/attribute"
 import { JsonapiTypeRegistry } from "../../src/jsonapi-type-registry"
-import { StorageBackend } from "../../src/local-storage"
+import { StorageBackend } from "../../src/credential-storage"
 import { JsonapiResource, JsonapiResponseDoc } from "../../src/index"
 
 import {
@@ -86,13 +86,13 @@ describe("Model", () => {
             })
           })
 
-          describe("when localStorage is configured", () => {
+          describe("when credentialStorage is configured", () => {
             let backend: StorageBackend
             const buildModel = () => {
               // need new class for this since it needs initialization to have the jwt config set
               @Model({
-                jwtLocalStorage: "MyJWT",
-                localStorageBackend: backend // Cast to any since we don't want this to be part of the standard model config interface. Just for test stubbing purposes
+                jwtStorage: "MyJWT",
+                credentialStorageBackend: backend // Cast to any since we don't want this to be part of the standard model config interface. Just for test stubbing purposes
               } as any)
               class Base extends JSORMBase {}
               BaseClass = Base
@@ -108,7 +108,7 @@ describe("Model", () => {
                 buildModel()
               })
 
-              it("adds to localStorage", () => {
+              it("adds to credentialStorage", () => {
                 BaseClass.setJWT("n3wt0k3n")
                 expect(backend.setItem).to.have.been.calledWith(
                   "MyJWT",


### PR DESCRIPTION
While localStorage is the default backend, I just remembered that the
sessionStorage API has the exact same type signature and can be used
interchangably, so there's no reason to name it in a way that confuses.