### PR TITLE
Split isPersisted() and reset()

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -405,6 +405,10 @@ export class JSORMBase {
   }
   set isPersisted(val: boolean) {
     this._persisted = val
+    this.reset()
+  }
+
+  reset() : void {
     this._originalAttributes = cloneDeep(this._attributes)
     this._originalRelationships = this.relationshipResourceIdentifiers(
       Object.keys(this.relationships)

--- a/src/util/deserialize.ts
+++ b/src/util/deserialize.ts
@@ -148,6 +148,7 @@ class Deserializer {
 
     // came from server, must be persisted
     instance.isPersisted = true
+    instance.reset()
 
     return instance
   }

--- a/test/integration/dirty-tracking.test.ts
+++ b/test/integration/dirty-tracking.test.ts
@@ -1,0 +1,44 @@
+import { sinon, expect, fetchMock } from "../test-helper"
+import { Person, Author, Book } from "../fixtures"
+import { IResultProxy } from "../../src/proxies/index"
+
+afterEach(() => {
+  fetchMock.restore()
+})
+
+let responsePayload = (firstName: string) => {
+  return {
+    data: {
+      id: "1",
+      type: "people",
+      attributes: { firstName }
+    }
+  }
+}
+
+beforeEach(() => {
+  let url = "http://example.com/api/v1/authors"
+  fetchMock.post(url, responsePayload('John'))
+  fetchMock.put(`${url}/1`, responsePayload('Jake'))
+})
+
+// This is a Vue-specific test. Since isPersisted is already true,
+// Vue will prevent the setter from firing. We cannot rely on
+// side-effect behavior of model.isPersisted = true
+// So, ensure we at least call reset() explicitly
+describe("Dirty tracking", () => {
+  describe("when persisted, dirty, updated", () => {
+    it("calls reset()", async () => {
+      let instance = new Author({ firstName: 'John' })
+      await instance.save()
+      expect(instance.isPersisted).to.eq(true)
+      expect(instance.isDirty()).to.eq(false)
+      instance.firstName = 'Jake'
+      expect(instance.isDirty()).to.eq(true)
+      let spy = sinon.spy()
+      instance.reset = spy
+      await instance.save()
+      expect(spy.callCount).to.eq(2)
+    })
+  })
+})

--- a/test/unit/model.test.ts
+++ b/test/unit/model.test.ts
@@ -817,6 +817,19 @@ describe("Model", () => {
       })
     })
 
+    describe('when previously persisted, dirty, then persisted again', () => {
+      it('is no longer dirty', () => {
+        const instance = new Author({ id: 1 })
+        instance.firstName = "foo"
+        instance.isPersisted = true
+        expect(instance.isDirty()).to.eq(false)
+        instance.firstName = "bar"
+        expect(instance.isDirty()).to.eq(true)
+        instance.isPersisted = true
+        expect(instance.isDirty()).to.eq(false)
+      })
+    })
+
     describe("when marked for destruction", () => {
       it("is dirty", () => {
         const instance = new Author()


### PR DESCRIPTION
Vue will avoid firing the setter if the getter returns the same value.
This ensures we do not rely on the setter's side-effect, but manually
call reset() to fix the issue.