### PR TITLE
Add simple Identity Map

### DIFF
--- a/src/associations.ts
+++ b/src/associations.ts
@@ -13,6 +13,10 @@ export interface Association {
   jsonapiType: string
 }
 
+const wasDestroyed = (model: JSORMBase) => {
+  return (model.isPersisted || model.stale) && !model.stored
+}
+
 export class SingleAssociationBase<T extends JSORMBase> extends Attribute<T>
   implements Association {
   isRelationship: true = true
@@ -40,6 +44,10 @@ export class SingleAssociationBase<T extends JSORMBase> extends Attribute<T>
   }
 
   getter(context: JSORMBase) {
+    let gotten = context.relationships[this.name] as JSORMBase | null
+    if (gotten && wasDestroyed(gotten)) {
+      delete context.relationships[this.name]
+    }
     return context.relationships[this.name]
   }
 
@@ -82,13 +90,16 @@ export class HasMany<T extends JSORMBase> extends Attribute<T[]>
   }
 
   getter(context: JSORMBase) {
-    const gotten = context.relationships[this.name]
+    const gotten = context.relationships[this.name] as JSORMBase[]
     if (!gotten) {
       this.setter(context, [])
       return context.relationships[this.name]
-    } else {
-      return gotten
     }
+
+    context.relationships[this.name] = gotten.filter((g) => {
+      return !wasDestroyed(g)
+    })
+    return context.relationships[this.name]
   }
 
   setter(context: JSORMBase, val: any): void {

--- a/src/attribute.ts
+++ b/src/attribute.ts
@@ -60,13 +60,14 @@ export class Attribute<T = any> {
   // The model calls this setter
   setter(context: JSORMBase, val: any): void {
     const privateContext: any = context
+    privateContext._attributeOverrides[this.name] = val
     privateContext._attributes[this.name] = val
   }
 
   // The model calls this getter
   getter(context: JSORMBase): any {
     const privateContext: any = context
-    return privateContext._attributes[this.name]
+    return privateContext.attributes[this.name]
   }
 
   // This returns the getters/setters for use on the *model*
@@ -92,8 +93,8 @@ const simpleCheckRE = /^(String|Number|Boolean|Function|Symbol)$/
 /*
  *  Function taken from VueJS's props assertion code here:
  *  https://github.com/vuejs/vue/blob/1dd6b6f046c3093950e599ccc6bbe7a393b8a494/src/core/util/props.js
- * 
- *  We aren't using this yet, but I don't want to lose the reference 
+ *
+ *  We aren't using this yet, but I don't want to lose the reference
  *  to it so I'm keeping it around.
  *
  */

--- a/src/id-map.ts
+++ b/src/id-map.ts
@@ -1,0 +1,51 @@
+import { JSORMBase } from "./model"
+import { Association } from "./associations"
+import { cloneDeep } from "./util/clonedeep"
+
+export class IDMap {
+  data: Record<string, any> = {}
+
+  get count() {
+    return Object.keys(this.data).length
+  }
+
+  find(model: JSORMBase, key: string | null = null) {
+    if (!key) key = model.storeKey
+    return this.data[key]
+  }
+
+  findAll(models: JSORMBase[]) {
+    let records: JSORMBase[] = []
+    models.forEach((m) => {
+      let found = this.find(m)
+      if (found) {
+        records.push(found)
+      }
+    })
+    return records
+  }
+
+  create(model: JSORMBase, key: string) {
+    model.storeKey = key
+    model.stale = false
+    this.data[key] = cloneDeep(model.attributes)
+  }
+
+  updateOrCreate(model: JSORMBase) {
+    if (model.storeKey) {
+      this.create(model, model.storeKey)
+    } else {
+      let key = this.keyFor(model)
+      this.create(model, key)
+    }
+  }
+
+  destroy(model: JSORMBase) {
+    model.stale = true
+    delete this.data[model.storeKey]
+  }
+
+  private keyFor(model: JSORMBase) {
+    return `${model.klass.jsonapiType}-${model.id}`
+  }
+}

--- a/src/util/deserialize.ts
+++ b/src/util/deserialize.ts
@@ -160,10 +160,9 @@ class Deserializer {
       if (relatedObjects) {
         if (Array.isArray(relatedObjects)) {
           relatedObjects.forEach((relatedObject, index) => {
-            if (
-              relatedObject.isMarkedForDestruction ||
-              relatedObject.isMarkedForDisassociation
-            ) {
+            if (relatedObject.isMarkedForDestruction) {
+              modelIdx.klass.store.destroy(relatedObject)
+            } else if (relatedObject.isMarkedForDisassociation) {
               modelIdx[key].splice(index, 1)
             } else {
               this._removeDeletions(relatedObject, includeDirective[key] || {})
@@ -171,10 +170,9 @@ class Deserializer {
           })
         } else {
           const relatedObject = relatedObjects
-          if (
-            relatedObject.isMarkedForDestruction ||
-            relatedObject.isMarkedForDisassociation
-          ) {
+          if (relatedObject.isMarkedForDestruction) {
+            modelIdx.klass.store.destroy(relatedObject)
+          } else if (relatedObject.isMarkedForDisassociation) {
             modelIdx[key] = null
           } else {
             this._removeDeletions(relatedObject, includeDirective[key] || {})

--- a/src/util/dirty-check.ts
+++ b/src/util/dirty-check.ts
@@ -19,6 +19,7 @@ class DirtyChecker<T extends JSORMBase> {
     if (relatedModel.isPersisted) {
       const identifiers: JsonapiResourceIdentifier[] =
         (<any>this.model)._originalRelationships[relationName] || []
+
       const found = identifiers.find(ri => {
         return (
           JSON.stringify(ri) === JSON.stringify(relatedModel.resourceIdentifier)

--- a/test/integration/id-map.test.ts
+++ b/test/integration/id-map.test.ts
@@ -1,0 +1,390 @@
+import { expect, fetchMock } from "../test-helper"
+import { ApplicationRecord, Author, Book, Bio } from "../fixtures"
+import { IDMap } from "../../src/id-map"
+
+afterEach(() => {
+  ApplicationRecord.store.data = {}
+})
+
+describe("ID Map", () => {
+  beforeEach(() => {
+    let responsePayload = (firstName: string) => {
+      return {
+        data: {
+          id: "1",
+          type: "authors",
+          attributes: { firstName }
+        }
+      }
+    }
+
+    fetchMock.get(
+      "http://example.com/api/v1/authors/1",
+      responsePayload('John')
+    )
+
+    fetchMock.delete("http://example.com/api/v1/authors/1", {
+      meta: {}
+    })
+
+    fetchMock.delete("http://example.com/api/books/1", {
+      meta: {}
+    })
+
+    fetchMock.delete("http://example.com/api/bios/1", {
+      meta: {}
+    })
+  })
+
+  afterEach(() => {
+    fetchMock.reset()
+  })
+
+  describe("when fetching from server", () => {
+    it("is added to the ID map", async () => {
+      let { data } = await Author.find(1)
+      let stored = ApplicationRecord.store.data
+      expect(Object.keys(stored)[0]).to.eq('authors-1')
+      expect(stored['authors-1']).to.deep.eq(data.attributes)
+    })
+
+    // A good way to think about this test:
+    //
+    // On the one hand, we want instances to sync - imagine a page
+    // that has a grid on the left, and a detail view on the right
+    // when you click a grid record. Both should always reflect the
+    // same global state.
+    //
+    // On the other hand, imagine that detail view was instead a form -
+    // we wouldn't want the user typing in the form to update the grid,
+    // until the form was saved.
+    it("syncs multiple instances", async () => {
+      fetchMock.put("http://example.com/api/v1/authors/1", {
+        data: {
+          id: "1",
+          type: "authors",
+          attributes: {
+            firstName: "updated"
+          }
+        }
+      })
+
+      let response = await Author.find(1)
+      let author1 = response.data
+      response = await Author.find(1)
+      let author2 = response.data
+
+      // not synced prior to save
+      author1.firstName = 'updated'
+      expect(author2.firstName).to.not.eq('updated')
+
+      await author1.save()
+
+      // now synced after save
+      expect(author2.firstName).to.eq('updated')
+
+      // now back to unsynced
+      author1.firstName = 'updated again'
+      expect(author2.firstName).to.eq('updated')
+    })
+  })
+
+  describe("when updated", () => {
+    beforeEach(() => {
+      fetchMock.get("http://example.com/api/books/1", {
+        data: {
+          id: "1",
+          type: "books",
+          attributes: {
+            title: "updated"
+          }
+        }
+      })
+
+      fetchMock.get("http://example.com/api/bios/1", {
+        data: {
+          id: "1",
+          type: "bios",
+          attributes: {
+            description: "updated"
+          }
+        }
+      })
+    })
+
+    describe('and associated to a hasMany relationship', () => {
+      let book: Book
+      let author: Author
+
+      beforeEach(() => {
+        book = new Book({ id: 1, title: 'original' })
+        book.isPersisted = true
+        author = new Author({ id: 1, books: [book] })
+      })
+
+      it("is also updated within the relationship", async () => {
+        expect(author.books[0].title).to.eq('original')
+        let { data } = await Book.find(1)
+        expect(data.title).to.eq('updated')
+        expect(author.books[0].title).to.eq('updated')
+      })
+    })
+
+    describe('and associated to a belongsTo relationship', () => {
+      let book: Book
+      let author: Author
+
+      beforeEach(() => {
+        author = new Author({ id: 1, firstName: 'original' })
+        author.isPersisted = true
+        book = new Book({ id: 1, author })
+        book.isPersisted = true
+      })
+
+      it("is also updated within the relationship", async () => {
+        expect(book.author.firstName).to.eq('original')
+        await Author.find(1)
+        expect(book.author.firstName).to.eq('John')
+      })
+    })
+
+    describe('and associated to a hasOne relationship', () => {
+      let author: Author
+      let bio: Bio
+
+      beforeEach(() => {
+        bio = new Bio({ id: 1, description: 'original' })
+        bio.isPersisted = true
+        author = new Author({ id: 1, bio })
+        author.isPersisted = true
+      })
+
+      it("is also updated within the relationship", async () => {
+        expect(author.bio.description).to.eq("original")
+        await Bio.find(1)
+        expect(author.bio.description).to.eq("updated")
+      })
+    })
+  })
+
+  describe("when destroyed via sideposting", () => {
+    beforeEach(async () => {
+      fetchMock.put("http://example.com/api/v1/authors/1", {
+        data: {
+          id: "1",
+          type: "authors"
+        }
+      })
+
+      fetchMock.put("http://example.com/api/books/1", {
+        data: {
+          id: "1",
+          type: "books"
+        }
+      })
+    })
+
+    describe("and associated to a hasMany relationship", () => {
+      let author: Author
+      let book: Book
+
+      beforeEach(async () => {
+        book = new Book({ id: 1 })
+        book.isPersisted = true
+        author = new Author({ id: 1, books: [book] })
+        author.isPersisted = true
+        book.isMarkedForDestruction = true
+        await author.save({ with: 'books' })
+      })
+
+      it("is removed from the ID map + relationship", async () => {
+        expect(book.stale).to.eq(true)
+        expect(ApplicationRecord.store.find(book)).to.eq(undefined)
+        expect(author.books).to.deep.eq([])
+      })
+    })
+
+    describe("and associated to a belongsTo relationship", () => {
+      let author: Author
+      let book: Book
+
+      beforeEach(async () => {
+        author = new Author({ id: 1 })
+        author.isPersisted = true
+        book = new Book({ id: 1, author })
+        book.isPersisted = true
+        author.isMarkedForDestruction = true
+        await book.save({ with: 'author' })
+      })
+
+      it("is removed from the ID map", async () => {
+        expect(author.stale).to.eq(true)
+        expect(ApplicationRecord.store.find(author)).to.eq(undefined)
+        expect(book.author).to.eq(undefined)
+      })
+    })
+
+    describe("and associated to a hasOne relationship", () => {
+      let author: Author
+      let bio: Bio
+
+      beforeEach(async () => {
+        bio = new Bio({ id: 1 })
+        bio.isPersisted = true
+        author = new Author({ id: 1, bio })
+        author.isPersisted = true
+        bio.isMarkedForDestruction = true
+        await author.save({ with: 'bio' })
+      })
+
+      it("is removed from the ID map", async () => {
+        expect(bio.stale).to.eq(true)
+        expect(ApplicationRecord.store.find(bio)).to.eq(undefined)
+        expect(author.bio).to.eq(undefined)
+      })
+    })
+  })
+
+  describe("when disassociated via sideposting", () => {
+    beforeEach(async () => {
+      fetchMock.put("http://example.com/api/v1/authors/1", {
+        data: {
+          id: "1",
+          type: "authors"
+        }
+      })
+
+      fetchMock.put("http://example.com/api/books/1", {
+        data: {
+          id: "1",
+          type: "books"
+        }
+      })
+    })
+
+    describe("and associated to a hasMany relationship", () => {
+      let author: Author
+      let book: Book
+
+      beforeEach(async () => {
+        book = new Book({ id: 1 })
+        book.isPersisted = true
+        author = new Author({ id: 1, books: [book] })
+        author.isPersisted = true
+        book.isMarkedForDisassociation = true
+        await author.save({ with: 'books' })
+      })
+
+      it("is still in the store, but removed from the relation", async () => {
+        expect(book.stale).to.eq(false)
+        expect(!!ApplicationRecord.store.find(book)).to.eq(true)
+        expect(author.books).to.deep.eq([])
+      })
+    })
+
+    describe("and associated to a belongsTo relationship", () => {
+      let author: Author
+      let book: Book
+
+      beforeEach(async () => {
+        author = new Author({ id: 1 })
+        author.isPersisted = true
+        book = new Book({ id: 1, author })
+        book.isPersisted = true
+        author.isMarkedForDisassociation = true
+        await book.save({ with: 'author' }) || this
+      })
+
+      it("is still in the store, but removed from the relation", async () => {
+        expect(author.stale).to.eq(false)
+        expect(!!ApplicationRecord.store.find(author)).to.eq(true)
+        expect(book.author).to.eq(null)
+      })
+    })
+
+    describe("and associated to a hasOne relationship", () => {
+      let author: Author
+      let bio: Bio
+
+      beforeEach(async () => {
+        bio = new Bio({ id: 1 })
+        bio.isPersisted = true
+        author = new Author({ id: 1, bio })
+        author.isPersisted = true
+        bio.isMarkedForDisassociation = true
+        await author.save({ with: 'bio' })
+      })
+
+      it("is still in the store, but removed from the relation", async () => {
+        expect(bio.stale).to.eq(false)
+        expect(!!ApplicationRecord.store.find(bio)).to.eq(true)
+        expect(author.bio).to.eq(null)
+      })
+    })
+  })
+
+  describe("when destroyed", () => {
+    it("is removed from the ID map", async () => {
+      let { data } = await Author.find(1)
+      expect(ApplicationRecord.store.count).to.eq(1)
+      await data.destroy()
+      expect(ApplicationRecord.store.count).to.eq(0)
+    })
+
+    describe('and associated to a hasMany relationship', () => {
+      let book: Book
+      let author: Author
+
+      beforeEach(() => {
+        author = new Author({ id: 1 })
+        author.isPersisted = true
+        book = new Book({ id: 1})
+        book.isPersisted = true
+        author.books = [book]
+      })
+
+      it('is no longer returned in the relationship', async () => {
+        expect(author.books.length).to.eq(1)
+        await book.destroy()
+        expect(ApplicationRecord.store.find(book)).to.eq(undefined)
+        expect(author.books.length).to.eq(0)
+      })
+    })
+
+    describe('and associated to a belongsTo relationship', () => {
+      let author: Author
+      let book: Book
+
+      beforeEach(() => {
+        author = new Author({ id: 1 })
+        author.isPersisted = true
+        book = new Book({ author, id: 1 })
+        book.isPersisted = true
+      })
+
+      it('is no longer returned in the relationship', async () => {
+        expect(book.author).to.not.eq(undefined)
+        await author.destroy()
+        expect(book.author).to.eq(undefined)
+      })
+    })
+
+    describe('and associated to a hasOne relationship', () => {
+      let author: Author
+      let bio: Bio
+
+      beforeEach(() => {
+        bio = new Bio({ id: 1 })
+        bio.isPersisted = true
+        author = new Author({ id: 1, bio })
+        author.isPersisted = true
+      })
+
+      it('is no longer returned in the relationship', async () => {
+        expect(author.bio).to.not.eq(undefined)
+        await bio.destroy()
+        expect(author.bio).to.eq(undefined)
+      })
+    })
+  })
+})

--- a/test/integration/nested-persistence.test.ts
+++ b/test/integration/nested-persistence.test.ts
@@ -318,7 +318,7 @@ describe("nested persistence", () => {
       instance.books[0].genre.isMarkedForDestruction = true
       await instance.save({ with: { books: "genre" } })
 
-      expect(instance.books[0].genre).to.eq(null)
+      expect(instance.books[0].genre).to.eq(undefined)
     })
   })
 
@@ -429,6 +429,8 @@ describe("nested persistence", () => {
         })
 
         it("still sends if id-only", async () => {
+          instance.books
+
           await instance.save({ with: { ["books.id"]: "genre.id" } })
           expect((<any>payloads)[0].included).to.deep.eq([
             {

--- a/test/integration/relations.test.ts
+++ b/test/integration/relations.test.ts
@@ -73,10 +73,7 @@ describe("Relations", () => {
     })
 
     it("contains the right records for each relationship", async () => {
-      const data = await resultData(
-        Author.includes(["books", "multi_words"]).find(1)
-      )
-
+      const { data } = await Author.includes(["books", "multi_words"]).find(1)
       expect(data.books[0].title).to.eql("The Shining")
       expect(data.multiWords[0].id).to.eql("multi_word1")
     })

--- a/test/unit/model-attributes.test.ts
+++ b/test/unit/model-attributes.test.ts
@@ -31,8 +31,6 @@ describe("Model attributes", () => {
     expect(person.attributes).to.eql({})
     person.firstName = "John"
     expect(person.attributes).to.eql({ firstName: "John" })
-    person.attributes.firstName = "Jane"
-    expect(person.firstName).to.eq("Jane")
   })
 
   it("sets attributes properties on the instance", () => {

--- a/test/unit/model.test.ts
+++ b/test/unit/model.test.ts
@@ -398,14 +398,14 @@ describe("Model", () => {
        * but the type definitions were VERY complicated, and in
        * simplifying them, it was necessary to omit the case
        * where one was going FROM javascript TO typescript,
-       * which seems like a far edge case when there aren't any 
+       * which seems like a far edge case when there aren't any
        * type definitions exported by the library as well, so I'm
-       * punting on it for now until I figure out a typings fix. 
-       * 
+       * punting on it for now until I figure out a typings fix.
+       *
        * Keeping the tests around with a lot of coercion to verify
        * the underlying functionality still works from a JS-only
        * perspective.
-       * 
+       *
        */
       describe("inheritance with class-based declaration", () => {
         class ExtendedPost extends (<any>Post) {
@@ -1094,7 +1094,7 @@ describe("Model", () => {
         instance.fromJsonapi(newDoc.data as JsonapiResource, newDoc, {
           books: { genre: {} }
         })
-        expect(instance.books[0].genre).to.eq(null)
+        expect(instance.books[0].genre).to.eq(undefined)
       })
 
       describe("within a nested destruction", () => {


### PR DESCRIPTION
* When persisted, model instances are registered with an in-memory
store. When deleted, they are removed from the store and the new `stale`
property becomes `true`.
* Model attributes are now synced across instances. If assigning an
attribute, that attribute will not be synced until save.
* When associations return related objects, they remove anything that
was deleted from the store. This way `await book.destroy()` will affect
the `author.books` relationship.