### PR TITLE
Ensure #dup() works correctly

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -5,6 +5,7 @@ import { refreshJWT } from "./util/refresh-jwt"
 import relationshipIdentifiersFor from "./util/relationship-identifiers"
 import { Request, RequestVerbs, JsonapiResponse } from "./request"
 import { WritePayload } from "./util/write-payload"
+import { flipEnumerable, getNonEnumerables } from "./util/enumerables"
 import {
   CredentialStorage,
   NullStorageBackend,
@@ -616,7 +617,12 @@ export class JSORMBase {
   }
 
   dup(): this {
-    return cloneDeep(this)
+    let nonEnums = getNonEnumerables(this)
+    flipEnumerable(this, nonEnums, true)
+    let cloned = cloneDeep(this)
+    flipEnumerable(this, nonEnums, false)
+    flipEnumerable(cloned, nonEnums, false)
+    return cloned
   }
 
   /*

--- a/src/util/decorators.ts
+++ b/src/util/decorators.ts
@@ -10,6 +10,7 @@ export const nonenumerable = (target: any, key: string) => {
       Object.defineProperty(this, key, {
         value: val,
         writable: true,
+        configurable: true,
         enumerable: false
       })
     },

--- a/src/util/enumerables.ts
+++ b/src/util/enumerables.ts
@@ -1,0 +1,18 @@
+export function flipEnumerable(instance: any, props: string[], to: boolean) : void {
+  props.forEach((propName) => {
+    let descriptor = Object.getOwnPropertyDescriptor(instance, propName)
+    descriptor.enumerable = to
+    Object.defineProperty(instance, propName, descriptor)
+  })
+}
+
+export function getNonEnumerables(instance: any) : string[] {
+  let nonEnums = [] as string[]
+  Object.getOwnPropertyNames(instance).forEach((propName) => {
+    let descriptor = Object.getOwnPropertyDescriptor(instance, propName)
+    if (!descriptor.enumerable) {
+      nonEnums.push(propName)
+    }
+  })
+  return nonEnums
+}

--- a/test/unit/model.test.ts
+++ b/test/unit/model.test.ts
@@ -1325,6 +1325,26 @@ describe("Model", () => {
     })
   })
 
+  describe("#dup()", () => {
+    it("returns a new instance of the same object", () => {
+      let author = new Author({ firstName: "Stephen" })
+      let duped = author.dup()
+      duped.firstName = "updated"
+      expect(author.firstName).to.eq("Stephen")
+      expect(duped.firstName).to.eq("updated")
+    })
+
+    it("does not recast nonenumerables to enumerable", () => {
+      let author = new Author({ firstName: "Stephen" })
+      let duped = author.dup()
+
+      let descriptor = Object.getOwnPropertyDescriptor(author, 'relationships')
+      expect(descriptor.enumerable).to.eq(false)
+      descriptor = Object.getOwnPropertyDescriptor(duped, 'relationships')
+      expect(descriptor.enumerable).to.eq(false)
+    })
+  })
+
   describe("#fetchOptions", () => {
     context("jwt is set", () => {
       beforeEach(() => {


### PR DESCRIPTION
Including copying all nonEnumerable properties. This works by casting to
enumerable (which cloneDeep requires), then recasting after the clone.