### PR TITLE
Avoid syncing dirty props on store update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build/
 test-old/
 dist/
 coverage/
+lib/
+lib-esm/

--- a/src/model.ts
+++ b/src/model.ts
@@ -439,14 +439,20 @@ export class JSORMBase {
     if (this._onStoreChange) return this._onStoreChange
     this._onStoreChange = (event, attrs) => {
       let diff = {} as any
+      // Update all non-dirty attributes
       Object.keys(attrs).forEach(k => {
         let self = this as any
-        if (self[k] !== attrs[k]) {
+        let changes = this.changes() as any
+        if (self[k] !== attrs[k] && !changes[k]) {
           diff[k] = [self[k], attrs[k]]
           self[k] = attrs[k]
+
+          // ensure this property is not marked as dirty
+          self._originalAttributes[k] = attrs[k]
         }
       })
 
+      // fire afterSync hook if applicable
       let hasDiff = Object.keys(diff).length > 0
       let hasAfterSync = typeof this.afterSync !== "undefined"
       if (hasDiff && hasAfterSync) this.afterSync(diff)


### PR DESCRIPTION
This is probably a better default, following principle of least
surprise, unless we hear otherwise. If you load instanceA, and 1m later
load instanceB with new data from the server, instanceA will change. But
if instanceA has already updated the relevant attribute (it is dirty),
avoid making that change.

Relatedly, if instanceA syncs with a new store update, it would see that
property as dirty, as it didn't match the attributes it was instantiated
with. This commit also ensures synced properties are not seen as dirty.