### PR TITLE
Ensure cache bust

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -36,8 +36,12 @@ export default class Request {
   }
 
   get(url : string, options: RequestInit) : Promise<any> {
-    options.method = 'GET';
-    return this._fetchWithLogging(url, options);
+    options.method = 'GET'
+    // Temp fix just in this version of jsorm
+    // Certain versions of ie11 will cache the response
+    options.headers['Pragma'] = 'no-cache'
+    options.headers['Cache-Control'] = 'no-cache, no-store'
+    return this._fetchWithLogging(url, options)
   }
 
   post(url: string, payload: Object, options: RequestInit) : Promise<any> {

--- a/test/integration/fetch-middleware-test.ts
+++ b/test/integration/fetch-middleware-test.ts
@@ -116,8 +116,10 @@ describe('fetch middleware', function() {
           expect(before.url).to.eq('http://example.com/api/v1/authors')
           expect(before.options).to.deep.eq({
             headers: {
-              Accept: 'application/json',
-              'Content-Type': 'application/json'
+              Accept: "application/json",
+              "Content-Type": "application/json",
+              "Cache-Control": "no-cache, no-store",
+              "Pragma": "no-cache"
             },
             method: 'GET'
           })


### PR DESCRIPTION
Certain versions of ie11 will cache the response. This forces a cache
bust in this version of jsorm; 1.x removes this in favor of server-side
caching.

http://mikko.repolainen.fi/posts/2016/12/21/ie-cache-with-fetch-and-aspnet-core.html