### PR TITLE
Upgrade to typescript 2.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ts-node": "4.0.1",
     "tslint": "5.9.0",
     "tslint-config-prettier": "1.6.0",
-    "typescript": "2.6.2",
+    "typescript": "2.8.3",
     "winston": "^2.3.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsorm",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Javascript ORM",
   "main": "lib/index.js",
   "module": "lib-esm/index.js",

--- a/src/associations.ts
+++ b/src/associations.ts
@@ -21,9 +21,9 @@ const wasDestroyed = (model: JSORMBase) => {
 export class SingleAssociationBase<T extends JSORMBase> extends Attribute<T>
   implements Association {
   isRelationship: true = true
-  jsonapiType: string
-  typeRegistry: JsonapiTypeRegistry
-  private _klass: typeof JSORMBase
+  jsonapiType!: string
+  typeRegistry!: JsonapiTypeRegistry
+  private _klass!: typeof JSORMBase
 
   constructor(options: AssociationRecord<T>) {
     super(options)
@@ -67,9 +67,9 @@ export class SingleAssociationBase<T extends JSORMBase> extends Attribute<T>
 export class HasMany<T extends JSORMBase> extends Attribute<T[]>
   implements Association {
   isRelationship: true = true
-  jsonapiType: string
-  typeRegistry: JsonapiTypeRegistry
-  private _klass: typeof JSORMBase
+  jsonapiType!: string
+  typeRegistry!: JsonapiTypeRegistry
+  private _klass!: typeof JSORMBase
 
   constructor(options: AssociationRecord<T>) {
     super(options as any)

--- a/src/attribute.ts
+++ b/src/attribute.ts
@@ -30,10 +30,10 @@ export type AttributeOptions = Partial<{
 
 export class Attribute<T = any> {
   isRelationship = false
-  name: string | symbol
+  name!: string | symbol
   type?: T = undefined
   persist: boolean = true
-  owner: typeof JSORMBase
+  owner!: typeof JSORMBase
 
   constructor(options: AttrRecord<T>) {
     if (!options) {

--- a/src/model.ts
+++ b/src/model.ts
@@ -121,7 +121,7 @@ export const applyModelConfig = <T extends typeof JSORMBase>(
   config = { ...config } // clone since we're going to mutate it
 
   // Handle all JWT configuration at once since it's run-order dependent
-  // We'll delete each key we encounter then pass the rest off to 
+  // We'll delete each key we encounter then pass the rest off to
   // a loop for assigning other arbitrary options
   if (config.credentialStorageBackend) {
     ModelClass.credentialStorageBackend = config.credentialStorageBackend
@@ -384,9 +384,9 @@ export class JSORMBase {
   stale: boolean = false
   storeKey: string = ""
 
-  @nonenumerable afterSync: (diff: Record<string, any>) => any | undefined
+  @nonenumerable afterSync?: (diff: Record<string, any>) => any | undefined
   @nonenumerable relationships: Record<string, JSORMBase | JSORMBase[]> = {}
-  @nonenumerable klass: typeof JSORMBase
+  @nonenumerable klass!: typeof JSORMBase
 
   @nonenumerable private _persisted: boolean = false
   @nonenumerable private _markedForDestruction: boolean = false
@@ -396,7 +396,7 @@ export class JSORMBase {
     string,
     JsonapiResourceIdentifier[]
   > = {}
-  @nonenumerable private _attributes: ModelRecord<this>
+  @nonenumerable private _attributes!: ModelRecord<this>
   @nonenumerable private _originalAttributes: ModelRecord<this>
   @nonenumerable private __meta__: any
   @nonenumerable private _errors: ValidationErrors<this> = {}
@@ -483,8 +483,9 @@ export class JSORMBase {
 
       // fire afterSync hook if applicable
       let hasDiff = Object.keys(diff).length > 0
-      let hasAfterSync = typeof this.afterSync !== "undefined"
-      if (hasDiff && hasAfterSync) this.afterSync(diff)
+      if (hasDiff && typeof this.afterSync !== "undefined") {
+        this.afterSync(diff)
+      }
     }
     return this._onStoreChange
   }

--- a/src/util/omit.ts
+++ b/src/util/omit.ts
@@ -1,3 +1,1 @@
-export type Diff<T extends string, U extends string> = ({ [P in T]: P } &
-  { [P in U]: never } & { [x: string]: never })[T]
-export type Omit<T, K extends keyof T> = { [P in Diff<keyof T, K>]: T[P] }
+export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>

--- a/src/util/validation-error-builder.ts
+++ b/src/util/validation-error-builder.ts
@@ -4,7 +4,7 @@ import {
   JsonapiError,
   JsonapiErrorMeta
 } from "../jsonapi-spec"
-import { ValidationErrors } from "../validation-errors"
+import { ValidationErrors, ValidationError } from "../validation-errors"
 
 export class ValidationErrorBuilder<T extends JSORMBase> {
   static apply<T extends JSORMBase>(
@@ -44,21 +44,20 @@ export class ValidationErrorBuilder<T extends JSORMBase> {
     this.model.errors = errorsAccumulator
   }
 
-  private _processResource(
-    errorsAccumulator: ValidationErrors<T>,
+  private _processResource<R extends JSORMBase=T>(
+    errorsAccumulator: ValidationErrors<R>,
     meta: JsonapiErrorMeta,
     error: JsonapiError
   ) {
     let attribute = this.model.klass.deserializeKey(meta.attribute)
-
     errorsAccumulator[attribute] = {
-      title: error.title,
-      code: error.code,
+      title: error.title as string,
+      code: error.code as string,
       attribute: meta.attribute,
       message: meta.message,
       fullMessage: attribute === "base" ? meta.message : error.detail,
       rawPayload: error,
-    } as any
+    }
   }
 
   private _processRelationship<R extends JSORMBase>(
@@ -66,7 +65,7 @@ export class ValidationErrorBuilder<T extends JSORMBase> {
     meta: JsonapiErrorMeta,
     err: JsonapiError
   ) {
-    let relatedObject = (<any>model)[meta.name]
+    let relatedObject = model[meta.name]
     if (Array.isArray(relatedObject)) {
       relatedObject = relatedObject.find(r => {
         return r.id === meta.id || r.temp_id === meta["temp-id"]

--- a/src/util/write-payload.ts
+++ b/src/util/write-payload.ts
@@ -32,7 +32,7 @@ export class WritePayload<T extends JSORMBase> {
     const attrs: ModelRecord<T> = {}
 
     this._eachAttribute((key, value) => {
-      if (!this.model.isPersisted || this.model.changes()[key]) {
+      if (!this.model.isPersisted || (<any>this.model.changes())[key]) {
         attrs[this.model.klass.serializeKey(key)] = value
       }
     })
@@ -241,13 +241,13 @@ export class WritePayload<T extends JSORMBase> {
     return false
   }
 
-  private _eachAttribute(callback: (key: keyof T, val: any) => void): void {
+  private _eachAttribute<K extends keyof T>(callback: (key: K, val: T[K]) => void): void {
     const modelAttrs = this.model.typedAttributes
 
     Object.keys(modelAttrs).forEach(key => {
       if (this.model.klass.attributeList[key].persist) {
         const value = modelAttrs[key]
-        callback(key as keyof T, value)
+        callback(key as K, value)
       }
     })
   }

--- a/src/validation-errors.ts
+++ b/src/validation-errors.ts
@@ -12,12 +12,12 @@ export interface IValidationError<T extends JSORMBase> {
 
 export class ValidationError<T extends JSORMBase>
   implements IValidationError<T> {
-  code: string
-  attribute: keyof ValidationErrors<T>
-  title: string
-  message: string
-  fullMessage: string
-  rawPayload: Record<string, any>
+  code!: string
+  attribute!: keyof ValidationErrors<T>
+  title!: string
+  message!: string
+  fullMessage!: string
+  rawPayload!: Record<string, any>
 
   constructor(options: IValidationError<T>) {
     let key: keyof IValidationError<T>
@@ -33,7 +33,18 @@ export type ValidationErrors<T extends JSORMBase> = ErrorAttrs<
   keyof (Omit<T, keyof JSORMBase>)
 >
 export type ErrorAttrs<T extends JSORMBase, K extends keyof T> = {
-  [P in K]?: ValidationError<T>
-} & { base?: ValidationError<T> }
+  [P in K]?: IValidationError<T> | undefined
+} & {
+  base?: IValidationError<T>
+  /*
+   * Index is necessary for typescript 2.8 compatibility. If we don't have
+   * this, the `@Model()` decorator doesn't work.  The error is that subclasses
+   * of JSORMBase with additional fields aren't compabible since their error
+   * objects aren't compatible. This is because ErrorAttrs<JSORMBase> doesn't
+   * have a key like e.g. "title", whereas ErrorAttrs<Post> will. Adding an
+   * index allowing undefined values will make these compatbile.
+   */
+  [key: string] : IValidationError<T> | undefined
+}
 
 let f = new JSORMBase()

--- a/test/integration/fetch-middleware.test.ts
+++ b/test/integration/fetch-middleware.test.ts
@@ -110,7 +110,7 @@ describe("fetch middleware", () => {
       if (url.indexOf("page") > -1) {
         shouldAbort = true
       }
-      if (options.body && options.body.indexOf("abortme") > -1) {
+      if (options.body && (options.body as string).indexOf("abortme") > -1) {
         shouldAbort = true
       }
 
@@ -118,7 +118,7 @@ describe("fetch middleware", () => {
         throw ABORT_ERR
       }
 
-      options.headers["CUSTOM-HEADER"] = "whatever"
+      ;(options.headers as Headers)["CUSTOM-HEADER"] = "whatever"
     })
 
     middleware.afterFilters.push((response, json) => {

--- a/test/integration/id-map.test.ts
+++ b/test/integration/id-map.test.ts
@@ -388,7 +388,7 @@ describe("ID Map", () => {
         book = new Book({ id: 1, author })
         book.isPersisted = true
         author.isMarkedForDisassociation = true
-        ;(await book.save({ with: "author" })) || this
+        ;(await book.save({ with: "author" }))
       })
 
       it("is still in the store, but removed from the relation", async () => {

--- a/test/unit/model.test.ts
+++ b/test/unit/model.test.ts
@@ -68,7 +68,7 @@ describe("Model", () => {
           afterEach(() => {
             ;(JSORMBase as any)._credentialStorage = originalStore
           })
-          
+
           context('localStorage API is present', () => {
             let localStorageStub: {
               getItem: SinonSpy
@@ -137,7 +137,7 @@ describe("Model", () => {
         describe('JWT Persistence', () => {
           beforeEach(() => {
             BaseClass.credentialStorageBackend = new InMemoryStorageBackend()
-          }) 
+          })
 
           describe("#getJWT", () => {
             beforeEach(() => {
@@ -1421,9 +1421,9 @@ describe("Model", () => {
       let author = new Author({ firstName: "Stephen" })
       let duped = author.dup()
 
-      let descriptor = Object.getOwnPropertyDescriptor(author, 'relationships')
+      let descriptor = Object.getOwnPropertyDescriptor(author, 'relationships') as PropertyDescriptor
       expect(descriptor.enumerable).to.eq(false)
-      descriptor = Object.getOwnPropertyDescriptor(duped, 'relationships')
+      descriptor = Object.getOwnPropertyDescriptor(duped, 'relationships') as PropertyDescriptor
       expect(descriptor.enumerable).to.eq(false)
     })
   })
@@ -1433,7 +1433,7 @@ describe("Model", () => {
       let stub : SinonStub
 
       beforeEach(() => {
-        stub = sinon.stub(ApplicationRecord, 'getJWT') 
+        stub = sinon.stub(ApplicationRecord, 'getJWT')
         stub.returns('g3tm3')
       })
 

--- a/test/unit/scope.test.ts
+++ b/test/unit/scope.test.ts
@@ -6,7 +6,7 @@ let scope: Scope<typeof Author>
 
 beforeEach(() => {
   const model = sinon.stub() as any
-  model['jsonapiType'] = "people"
+  model.jsonapiType = "people"
   scope = new Scope(model)
 })
 

--- a/test/unit/write-payload.test.ts
+++ b/test/unit/write-payload.test.ts
@@ -3,7 +3,7 @@ import { WritePayload } from "../../src/util/write-payload"
 import { Person, PersonWithDasherizedKeys } from "../fixtures"
 
 describe("WritePayload", () => {
-  it("underscores attributes", function() {
+  it("underscores attributes", () => {
     let person = new Person({ first_name: "Joe" })
     let payload = new WritePayload(person, true)
     expect(payload.asJSON()).to.deep.equal({
@@ -16,7 +16,7 @@ describe("WritePayload", () => {
     })
   })
 
-  it("dasherizes attributes", function() {
+  it("dasherizes attributes", () => {
     let person = new PersonWithDasherizedKeys({ first_name: "Joe" })
     let payload = new WritePayload(person, true)
     expect(payload.asJSON()).to.deep.equal({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "importHelpers": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": true,
+    "suppressImplicitAnyIndexErrors": true,
     "noLib": false,
     "removeComments": false,
     "strict": true,


### PR DESCRIPTION
When consuming JSORM from a typescript 2.8 project there were some
unexpected type errors. In order to resolve these, it was necessary to
upgrade this to the newest version so to better detect the errors and
fix them in this library.