### PR TITLE
Fix WhereClause type

### DIFF
--- a/src/scope.ts
+++ b/src/scope.ts
@@ -31,7 +31,7 @@ export type SortDir = "asc" | "desc"
 export type SortScope = Record<string, SortDir>
 export type FieldScope = Record<string, string[]>
 export type FieldArg = FieldScope | string[]
-export type WhereClause = Record<string, string | number | boolean>
+export type WhereClause = Record<string, string | number | boolean | string[] | number[]>
 export type StatsScope = Record<string, string | string[]>
 export type IncludeScope = string | IncludeArgHash | (string | IncludeArgHash)[]
 

--- a/test/integration/finders.test.ts
+++ b/test/integration/finders.test.ts
@@ -272,6 +272,23 @@ describe("Model finders", () => {
       expect(data[0]).to.have.property("id", "2")
     })
 
+    describe("when value is an array", () => {
+      beforeEach(() => {
+        fetchMock.reset()
+        fetchMock.get(
+          "http://example.com/api/v1/people?filter[id]=1,2,3",
+          {
+            data: [{ id: "2", type: "people" }]
+          }
+        )
+      })
+
+      it('converts to comma-delimited string', async () => {
+        const { data } = await Person.where({ id: [1, 2, 3] }).all()
+        expect(data.length).to.eq(1)
+      })
+    })
+
     describe("when value is false", () => {
       beforeEach(() => {
         fetchMock.reset()


### PR DESCRIPTION
You can pass an array to where, like:

```ts
Post.where({ id: [1, 2, 3] })
```

This will be converted to `?filter[id]=1,2,3`.

This logic was already working, but the type was incorrect. Added a test
for good measure.