### PR TITLE
Prevent setPrototypeOf from interfering with non-JSORM v0 objects

### DIFF
--- a/src/custom-extend.ts
+++ b/src/custom-extend.ts
@@ -15,7 +15,7 @@ const patchExtends = function() {
   Object['setPrototypeOf'] = function(subClass, superClass) {
     originalSetPrototypeOf(subClass, superClass);
 
-    if(superClass['inherited']) {
+    if(superClass['inherited'] && superClass['jsormVersion'] == 0) {
       superClass['inherited'](subClass);
     }
   }

--- a/src/model.ts
+++ b/src/model.ts
@@ -44,6 +44,7 @@ export default class Model {
   klass: typeof Model;
 
   static attributeList = {};
+  static jsormVersion = 0;
   private static _scope: Scope;
 
   static extend(obj : any) : any {


### PR DESCRIPTION
The superclass#inherited is causing JSORM v1 objects to have a
prototype of the superclass.