### PR TITLE
Fix asQueryParams URL encoding issues for GET requests

### DIFF
--- a/src/util/parameterize.ts
+++ b/src/util/parameterize.ts
@@ -1,3 +1,17 @@
+const encodeTokens = ['&', '?', '#']
+const encodeTokensMatch = new RegExp(`[\\${encodeTokens.join('\\')}]`)
+const encodeTokenMapping = encodeTokens.map(token => {
+  return [new RegExp(`\\${token}`, 'g'), encodeURIComponent(token)]
+})
+
+const encodeParameter = (value: string): string => {
+  let newValue: string = `${value}`
+  if (newValue.match(encodeTokensMatch)) {
+    encodeTokenMapping.forEach(mapping => newValue = newValue.replace.apply(newValue, mapping))
+  }
+  return newValue
+}
+
 const parameterize = (obj: any, prefix?: string): string => {
   let str = []
 
@@ -12,12 +26,12 @@ const parameterize = (obj: any, prefix?: string): string => {
 
         if (Array.isArray(value)) {
           if (value.length > 0) {
-            str.push(`${key}=${value.join(",")}`)
+            str.push(`${key}=${value.map(encodeParameter).join(",")}`)
           }
         } else if (typeof value === "object") {
           str.push(parameterize(value, key))
         } else {
-          str.push(`${key}=${value}`)
+          str.push(`${key}=${encodeParameter(value)}`)
         }
       }
     }

--- a/test/integration/finders.test.ts
+++ b/test/integration/finders.test.ts
@@ -332,7 +332,28 @@ describe("Model finders", () => {
         expect(data[0]).to.be.instanceof(Person)
       })
     })
-  })
+
+    describe("when value is has special tokens", () => {
+      beforeEach(() => {
+        fetchMock.reset()
+        fetchMock.get(
+          "http://example.com/api/v1/people?filter[id]=2&filter[a]={{Penn %26 Teller %235%3F}}",
+          {
+            data: [{ id: "2", type: "people" }]
+          }
+        )
+      })
+
+      it("still queries correctly", async () => {
+        const { data } = await Person.where({ id: 2 })
+          .where({ a: "{{Penn & Teller #5?}}" })
+          .all()
+
+        expect(data.length).to.eq(1)
+        expect(data[0]).to.be.instanceof(Person)
+        expect(data[0]).to.have.property("id", "2")
+      })
+    })  })
 
   describe("#stats", () => {
     beforeEach(() => {


### PR DESCRIPTION
When the field or other type of data has html entities in them (i.e.
ampersands), since the data is not encoded for GET requests the
JSORM url will be incidentally broken.  For obvious reasons, POST
requests shouldn't have this issue.

encodeURIComponent encodes a lot of useful characters that doesn't
actually need to be encoded for the brower, so we are only encoding
the tokens that are likely to cause issues.