### PR TITLE
Relax package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,11 +72,11 @@
     "winston": "^2.3.1"
   },
   "dependencies": {
-    "debug": "3.1.0",
-    "eventbusjs": "0.2.0",
-    "inflected": "2.0.3",
-    "lodash": "4.17.10",
-    "lodash-es": "4.17.4",
-    "tslib": "1.8.1"
+    "debug": "^4.0.0",
+    "eventbusjs": "^0.2.0",
+    "inflected": "^2.0.3",
+    "lodash": "^4.17.10",
+    "lodash-es": "^4.17.4",
+    "tslib": "^1.8.1"
   }
 }


### PR DESCRIPTION
These being fixed to a particular version resulted in extra versions of
the dependency in consumers' node_modules tree/output bundles.