### PR TITLE
Default Accept and Content-Type headers to application/vnd.api+json

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -671,8 +671,8 @@ export class JSORMBase {
   static fetchOptions(): RequestInit {
     const options = {
       headers: {
-        Accept: "application/json",
-        ["Content-Type"]: "application/json"
+        Accept: "application/vnd.api+json",
+        ["Content-Type"]: "application/vnd.api+json"
       } as any
     }
 

--- a/test/integration/fetch-middleware.test.ts
+++ b/test/integration/fetch-middleware.test.ts
@@ -152,8 +152,8 @@ describe("fetch middleware", () => {
           expect(before.url).to.eq("http://example.com/api/v1/authors")
           expect(before.options).to.deep.eq({
             headers: {
-              Accept: "application/json",
-              "Content-Type": "application/json",
+              Accept: "application/vnd.api+json",
+              "Content-Type": "application/vnd.api+json",
               "CUSTOM-HEADER": "whatever"
             },
             method: "GET"
@@ -309,9 +309,9 @@ describe("fetch middleware", () => {
           expect(before.url).to.eq("http://example.com/api/v1/authors")
           expect(before.options).to.deep.eq({
             headers: {
-              Accept: "application/json",
+              Accept: "application/vnd.api+json",
               "CUSTOM-HEADER": "whatever",
-              "Content-Type": "application/json"
+              "Content-Type": "application/vnd.api+json"
             },
             body: JSON.stringify({ data: { type: "authors" } }),
             method: "POST"

--- a/test/unit/model.test.ts
+++ b/test/unit/model.test.ts
@@ -1485,8 +1485,8 @@ describe("Model", () => {
 
     it("includes the content headers", () => {
       const headers: any = Author.fetchOptions().headers
-      expect(headers.Accept).to.eq("application/json")
-      expect(headers["Content-Type"]).to.eq("application/json")
+      expect(headers.Accept).to.eq("application/vnd.api+json")
+      expect(headers["Content-Type"]).to.eq("application/vnd.api+json")
     })
   })
 })


### PR DESCRIPTION
According to the JSON:API spec:

> Clients MUST send all JSON:API data in request documents with the header Content-Type: application/vnd.api+json without any media type parameters.

This PR updates the defaults for the `Accept` and `Content-Type` to match the spec.

https://jsonapi.org/format/#content-negotiation-clients